### PR TITLE
feat: ajout d'un unvalidate cache quand une ressource n'a pas été trouvé

### DIFF
--- a/src/pages/apprentissage/[id].tsx
+++ b/src/pages/apprentissage/[id].tsx
@@ -16,9 +16,7 @@ interface ConsulterOffreAlternancePageProps {
   offreAlternance: RésultatRechercheAlternance;
 }
 
-export default function ConsulterOffreAlternancePage(props: ConsulterOffreAlternancePageProps) {
-  const { offreAlternance } = props;
-
+export default function ConsulterOffreAlternancePage({ offreAlternance }: ConsulterOffreAlternancePageProps) {
   if (!offreAlternance) return null;
 
   return (
@@ -43,7 +41,7 @@ export async function getStaticProps(context: GetStaticPropsContext<AlternanceCo
   const alternanceId = split[1] as AlternanceId;
   const offreAlternance = await dependencies.alternanceDependencies.consulterOffreAlternance.handle(alternanceId, from);
   if (offreAlternance.instance === 'failure') {
-    return { notFound: true };
+    return { notFound: true, revalidate: 1 };
   }
 
   return {

--- a/src/pages/articles/[id].tsx
+++ b/src/pages/articles/[id].tsx
@@ -12,9 +12,7 @@ interface ConsulterArticlePageProps {
 	article: Article
 }
 
-export default function ConsulterArticlePage(props: ConsulterArticlePageProps) {
-  const { article } = props;
-
+export default function ConsulterArticlePage({ article }: ConsulterArticlePageProps) {
   if (!article) return null;
 
   return (
@@ -38,7 +36,7 @@ export async function getStaticProps(context: GetStaticPropsContext<ArticleConte
   const response = await dependencies.articleDependencies.consulterArticle.handle(id);
 
   if (response.instance === 'failure') {
-    return { notFound: true };
+    return { notFound: true, revalidate: 1 };
   }
 
   return {

--- a/src/pages/emplois/[id].tsx
+++ b/src/pages/emplois/[id].tsx
@@ -12,9 +12,7 @@ interface ConsulterOffreEmploiPageProps {
   offreEmploi: OffreEmploi;
 }
 
-export default function ConsulterOffreEmploiPage(props: ConsulterOffreEmploiPageProps) {
-  const { offreEmploi } = props;
-
+export default function ConsulterOffreEmploiPage({ offreEmploi }: ConsulterOffreEmploiPageProps) {
   if (!offreEmploi) return null;
 
   return (
@@ -37,7 +35,7 @@ export async function getStaticProps(context: GetStaticPropsContext<EmploiContex
   const offreEmploi = await dependencies.offreEmploiDependencies.consulterOffreEmploi.handle(id);
 
   if (offreEmploi.instance === 'failure') {
-    return { notFound: true };
+    return { notFound: true, revalidate: 1 };
   }
 
   return {

--- a/src/pages/jobs-etudiants/[id].tsx
+++ b/src/pages/jobs-etudiants/[id].tsx
@@ -12,9 +12,7 @@ interface ConsulterJobEtudiantPageProps {
   jobEtudiant: OffreEmploi;
 }
 
-export default function ConsulterJobEtudiantPage(props: ConsulterJobEtudiantPageProps) {
-  const { jobEtudiant } = props;
-
+export default function ConsulterJobEtudiantPage({ jobEtudiant }: ConsulterJobEtudiantPageProps) {
   if (!jobEtudiant) return null;
 
   return (
@@ -37,7 +35,7 @@ export async function getStaticProps(context: GetStaticPropsContext<EmploiContex
   const offreEmploi = await dependencies.offreEmploiDependencies.consulterOffreEmploi.handle(id);
 
   if (offreEmploi.instance === 'failure') {
-    return { notFound: true };
+    return { notFound: true, revalidate: 1 };
   }
 
   return {


### PR DESCRIPTION
J'ai testé ça : [https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#on-demand-revalidation-beta](https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#on-demand-revalidation-beta) mais ça marche pas tip top moumoute (c'est seulement en beta il parle de sortir des optims +lts à la version 13 de next) par contre je pense que c'est la solution cible donc j'ai noté cette solution dans le board tech :)

Sinon pour tester en mode TU c'était pas possible (par contre j'ai trouvé une lib de test de page directement et pas que de composant [https://www.npmjs.com/package/next-page-tester](https://www.npmjs.com/package/next-page-tester) mais ces salows sont encore en react 17...) mais ce que j'ai fait c'est que j'ai collé un compteur dans le code pour simuler un premier appel 404 avec le `revalidate: 1` puis un deuxième appel avec une ressource trouvée et tu vois qu'ensuite le code passe plus dans le static il renvoie direct du html depuis le serveur