### PR TITLE
[BSR]: Revalidation SSG plus fréquente sur les review apps

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "IS_REVIEW_APP": {
+      "value": "true"
+    }
+  }
+}

--- a/src/pages/apprentissage/[id].tsx
+++ b/src/pages/apprentissage/[id].tsx
@@ -50,7 +50,7 @@ export async function getStaticProps(context: GetStaticPropsContext<AlternanceCo
     props: {
       alternanceFromMatcha: JSON.parse(JSON.stringify(offreAlternance.result)),
     },
-    revalidate: 86400,
+    revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
   };
 }
 

--- a/src/pages/articles/[id].tsx
+++ b/src/pages/articles/[id].tsx
@@ -43,7 +43,7 @@ export async function getStaticProps(context: GetStaticPropsContext<ArticleConte
     props: {
       article: JSON.parse(JSON.stringify(response.result)),
     },
-    revalidate: 86400,
+    revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
   };
 
 }

--- a/src/pages/benevolat/[id].tsx
+++ b/src/pages/benevolat/[id].tsx
@@ -42,7 +42,7 @@ export async function getStaticProps(context: GetStaticPropsContext<MissionConte
     props: {
       missionEngagement: JSON.parse(JSON.stringify(missionEngagement.result)),
     },
-    revalidate: 86400,
+    revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
   };
 }
 

--- a/src/pages/confidentialite/index.tsx
+++ b/src/pages/confidentialite/index.tsx
@@ -24,5 +24,6 @@ export async function getStaticProps(): Promise<GetStaticPropsResult<ConsulterCo
       contenu,
       titre,
     },
+    revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
   };
 }

--- a/src/pages/emplois/[id].tsx
+++ b/src/pages/emplois/[id].tsx
@@ -42,7 +42,7 @@ export async function getStaticProps(context: GetStaticPropsContext<EmploiContex
     props: {
       offreEmploi: JSON.parse(JSON.stringify(offreEmploi.result)),
     },
-    revalidate: 86400,
+    revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
   };
 }
 

--- a/src/pages/jobs-etudiants/[id].tsx
+++ b/src/pages/jobs-etudiants/[id].tsx
@@ -42,7 +42,7 @@ export async function getStaticProps(context: GetStaticPropsContext<EmploiContex
     props: {
       jobEtudiant: JSON.parse(JSON.stringify(offreEmploi.result)),
     },
-    revalidate: 86400,
+    revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
   };
 }
 

--- a/src/pages/mentorat/index.tsx
+++ b/src/pages/mentorat/index.tsx
@@ -136,9 +136,3 @@ function RaisonParticipationsMentorat() {
     </section>
   );
 }
-
-export async function getStaticProps() {
-  return {
-    props: {},
-  };
-}

--- a/src/pages/mesures-jeunes/index.tsx
+++ b/src/pages/mesures-jeunes/index.tsx
@@ -26,7 +26,7 @@ export async function getStaticProps(): Promise<GetStaticPropsResult<MesuresJeun
     props: {
       mesuresJeunes: JSON.parse(JSON.stringify(response.result)),
     },
-    revalidate: 86400,
+    revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
   };
 }
 

--- a/src/pages/service-civique/[id].tsx
+++ b/src/pages/service-civique/[id].tsx
@@ -42,7 +42,7 @@ export async function getStaticProps(context: GetStaticPropsContext<MissionConte
     props: {
       missionEngagement: JSON.parse(JSON.stringify(missionEngagement.result)),
     },
-    revalidate: 86400,
+    revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
   };
 }
 

--- a/src/server/cms/configuration/cmsDependencies.container.ts
+++ b/src/server/cms/configuration/cmsDependencies.container.ts
@@ -2,20 +2,25 @@ import { StrapiCmsRepository } from '~/server/cms/infra/repositories/strapiCms.r
 import { ConsulterArticleUseCase } from '~/server/cms/useCases/consulterArticle.useCase';
 import { ConsulterMentionObligatoireUseCase } from '~/server/cms/useCases/consulterMentionObligatoireUseCase';
 import { RécupérerMesuresJeunesUseCase } from '~/server/cms/useCases/récupérerMesuresJeunesUseCase';
+import { ConfigurationService } from '~/server/services/configuration.service';
 import { HttpClientService } from '~/server/services/http/httpClient.service';
 
 export interface CmsDependencies {
   consulterArticle: ConsulterArticleUseCase
   consulterMentionObligatoire: ConsulterMentionObligatoireUseCase
   récupérerMesuresJeunes: RécupérerMesuresJeunesUseCase
+  duréeDeValiditéEnSecondes: () => number
 }
 
-export const cmsDependenciesContainer = (httpClientService: HttpClientService): CmsDependencies => {
+export const cmsDependenciesContainer = (httpClientService: HttpClientService, configurationService: ConfigurationService): CmsDependencies => {
   const repository = new StrapiCmsRepository(httpClientService);
+  const { IS_REVIEW_APP } = configurationService.getConfiguration();
+  const duréeDeValidité = IS_REVIEW_APP ? 60 : 60 * 60 * 24;
 
   return {
     consulterArticle: new ConsulterArticleUseCase(repository),
     consulterMentionObligatoire: new ConsulterMentionObligatoireUseCase(repository),
+    duréeDeValiditéEnSecondes: () => duréeDeValidité,
     récupérerMesuresJeunes: new RécupérerMesuresJeunesUseCase(repository),
   };
 };

--- a/src/server/cms/configuration/cmsDependencies.container.ts
+++ b/src/server/cms/configuration/cmsDependencies.container.ts
@@ -15,7 +15,7 @@ export interface CmsDependencies {
 export const cmsDependenciesContainer = (httpClientService: HttpClientService, configurationService: ConfigurationService): CmsDependencies => {
   const repository = new StrapiCmsRepository(httpClientService);
   const { IS_REVIEW_APP } = configurationService.getConfiguration();
-  const duréeDeValidité = IS_REVIEW_APP ? 60 : 60 * 60 * 24;
+  const duréeDeValidité = IS_REVIEW_APP ? 20 : 60 * 60 * 24;
 
   return {
     consulterArticle: new ConsulterArticleUseCase(repository),

--- a/src/server/configuration/dependencies.container.ts
+++ b/src/server/configuration/dependencies.container.ts
@@ -67,13 +67,13 @@ export const dependenciesContainer = (): Dependencies => {
     strapiClientService,
     poleEmploiClientService,
   } = buildHttpClientConfigList(serverConfigurationService);
-  
+
   const { NEXT_PUBLIC_STAGE_SEARCH_ENGINE_API_KEY, NEXT_PUBLIC_STAGE_SEARCH_ENGINE_BASE_URL } = serverConfigurationService.getConfiguration();
   const meiliSearchClient = new MeiliSearch({ apiKey: NEXT_PUBLIC_STAGE_SEARCH_ENGINE_API_KEY, host: NEXT_PUBLIC_STAGE_SEARCH_ENGINE_BASE_URL });
 
   const apiPoleEmploiRéférentielRepository = new ApiPoleEmploiRéférentielRepository(poleEmploiClientService, cacheService);
 
-  const cmsDependencies = cmsDependenciesContainer(strapiClientService);
+  const cmsDependencies = cmsDependenciesContainer(strapiClientService, serverConfigurationService);
   const offreEmploiDependencies = offresEmploiDependenciesContainer(poleEmploiClientService, apiPoleEmploiRéférentielRepository);
   const alternanceDependencies = alternanceDependenciesContainer(laBonneAlternanceClientService);
   const engagementDependencies = engagementDependenciesContainer(engagementClientService);
@@ -89,7 +89,7 @@ export const dependenciesContainer = (): Dependencies => {
   return {
     alternanceDependencies,
     cmsDependencies,
-    demandeDeContactDependencies: demandeDeContactDependencies,
+    demandeDeContactDependencies,
     engagementDependencies,
     entrepriseDependencies,
     fichesMetierDependencies,

--- a/src/server/services/serverConfiguration.service.ts
+++ b/src/server/services/serverConfiguration.service.ts
@@ -9,6 +9,7 @@ export class ServerConfigurationService implements ConfigurationService {
       API_GEO_BASE_URL: ServerConfigurationService.getOrThrowError('API_GEO_BASE_URL'),
       API_LA_BONNE_ALTERNANCE_BASE_URL: ServerConfigurationService.getOrThrowError('API_LA_BONNE_ALTERNANCE_BASE_URL'),
       API_POLE_EMPLOI_BASE_URL: ServerConfigurationService.getOrThrowError('API_POLE_EMPLOI_BASE_URL'),
+      IS_REVIEW_APP: ServerConfigurationService.getOrDefault('IS_REVIEW_APP', ''),
       NEXT_PUBLIC_STAGE_SEARCH_ENGINE_API_KEY: ServerConfigurationService.getOrThrowError('NEXT_PUBLIC_STAGE_SEARCH_ENGINE_API_KEY'),
       NEXT_PUBLIC_STAGE_SEARCH_ENGINE_BASE_URL: ServerConfigurationService.getOrThrowError('NEXT_PUBLIC_STAGE_SEARCH_ENGINE_BASE_URL'),
       POLE_EMPLOI_CONNECT_CLIENT_ID: ServerConfigurationService.getOrThrowError('POLE_EMPLOI_CONNECT_CLIENT_ID'),
@@ -34,6 +35,11 @@ export class ServerConfigurationService implements ConfigurationService {
       return environmentVariable;
     }
   }
+
+  private static getOrDefault(name: string, defaultValue: string): string {
+    const environmentVariable = process.env[name];
+    return environmentVariable || defaultValue;
+  }
 }
 
 class EnvironmentVariablesException extends Error {
@@ -49,12 +55,13 @@ export interface EnvironmentVariables {
   readonly API_GEO_BASE_URL: string;
   readonly API_LA_BONNE_ALTERNANCE_BASE_URL: string;
   readonly API_POLE_EMPLOI_BASE_URL: string;
+  readonly IS_REVIEW_APP: string
   readonly NEXT_PUBLIC_STAGE_SEARCH_ENGINE_API_KEY: string;
   readonly NEXT_PUBLIC_STAGE_SEARCH_ENGINE_BASE_URL: string;
-  readonly POLE_EMPLOI_CONNECT_URL: string;
   readonly POLE_EMPLOI_CONNECT_CLIENT_ID: string;
   readonly POLE_EMPLOI_CONNECT_CLIENT_SECRET: string;
   readonly POLE_EMPLOI_CONNECT_SCOPE: string;
+  readonly POLE_EMPLOI_CONNECT_URL: string;
   readonly REDIS_DB: number;
   readonly REDIS_HOST: string;
   readonly REDIS_PASSWORD: string;

--- a/tests/fixtures/services/configuration.service.fixture.ts
+++ b/tests/fixtures/services/configuration.service.fixture.ts
@@ -10,6 +10,7 @@ export class ConfigurationServiceFixture implements ConfigurationService {
       API_GEO_BASE_URL: 'https://geo.api.gouv.fr/',
       API_LA_BONNE_ALTERNANCE_BASE_URL: 'https://labonnealternance.apprentissage.beta.gouv.fr/api/V1/',
       API_POLE_EMPLOI_BASE_URL: 'https://api.emploi-store.fr/',
+      IS_REVIEW_APP: '',
       NEXT_PUBLIC_STAGE_SEARCH_ENGINE_API_KEY: 'notTheMasterKey',
       NEXT_PUBLIC_STAGE_SEARCH_ENGINE_BASE_URL: 'http://localhost:7700',
       POLE_EMPLOI_CONNECT_CLIENT_ID: 'POLE_EMPLOI_CONNECT_CLIENT_ID',


### PR DESCRIPTION
- va chercher le paramètres `revalidate` dans un service pour `getStaticProps`
- le service utilise une durée plus courte lorsque la config `IS_REVIEW_APP` est présente
- configure automatiquement `IS_REVIEW_APP` dans les review apps