### PR TITLE
tech: remove useless ssg

### DIFF
--- a/src/pages/apprentissage/[id].tsx
+++ b/src/pages/apprentissage/[id].tsx
@@ -1,16 +1,11 @@
-import { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import { GetStaticPropsContext, GetStaticPropsResult } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import React from 'react';
 
 import { ConsulterOffreAlternance } from '~/client/components/features/Alternance/Consulter/ConsulterOffreAlternance';
 import { HeadTag } from '~/client/components/utils/HeaderTag';
-import {
-  AlternanceId,
-  From,
-} from '~/server/alternances/domain/alternance';
-import {
-  ConsulterOffreAlternanceMatcha,
-} from '~/server/alternances/infra/repositories/alternance.type';
+import { AlternanceId, From } from '~/server/alternances/domain/alternance';
+import { ConsulterOffreAlternanceMatcha } from '~/server/alternances/infra/repositories/alternance.type';
 import { PageContextParamsException } from '~/server/exceptions/pageContextParams.exception';
 import { dependencies } from '~/server/start';
 
@@ -51,13 +46,5 @@ export async function getStaticProps(context: GetStaticPropsContext<AlternanceCo
       alternanceFromMatcha: JSON.parse(JSON.stringify(offreAlternance.result)),
     },
     revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
-  };
-}
-
-export async function getStaticPaths(): Promise<GetStaticPathsResult> {
-
-  return {
-    fallback: true,
-    paths: [],
   };
 }

--- a/src/pages/articles/[id].tsx
+++ b/src/pages/articles/[id].tsx
@@ -1,4 +1,4 @@
-import { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import { GetStaticPropsContext, GetStaticPropsResult } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import React from 'react';
 
@@ -9,7 +9,7 @@ import { PageContextParamsException } from '~/server/exceptions/pageContextParam
 import { dependencies } from '~/server/start';
 
 interface ConsulterArticlePageProps {
-	article: Article
+  article: Article;
 }
 
 export default function ConsulterArticlePage({ article }: ConsulterArticlePageProps) {
@@ -24,7 +24,7 @@ export default function ConsulterArticlePage({ article }: ConsulterArticlePagePr
 }
 
 interface ArticleContext extends ParsedUrlQuery {
-  id: ArticleSlug
+  id: ArticleSlug;
 }
 
 export async function getStaticProps(context: GetStaticPropsContext<ArticleContext>): Promise<GetStaticPropsResult<ConsulterArticlePageProps>> {
@@ -46,11 +46,4 @@ export async function getStaticProps(context: GetStaticPropsContext<ArticleConte
     revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
   };
 
-}
-
-export async function getStaticPaths(): Promise<GetStaticPathsResult> {
-  return {
-    fallback: true,
-    paths: [],
-  };
 }

--- a/src/pages/benevolat/[id].tsx
+++ b/src/pages/benevolat/[id].tsx
@@ -1,8 +1,10 @@
-import { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import { GetStaticPropsContext, GetStaticPropsResult } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import React from 'react';
 
-import { ConsulterMissionEngagement } from '~/client/components/features/Engagement/Consulter/ConsulterMissionEngagement';
+import {
+  ConsulterMissionEngagement,
+} from '~/client/components/features/Engagement/Consulter/ConsulterMissionEngagement';
 import { HeadTag } from '~/client/components/utils/HeaderTag';
 import { Mission, MissionId } from '~/server/engagement/domain/engagement';
 import { PageContextParamsException } from '~/server/exceptions/pageContextParams.exception';
@@ -18,7 +20,7 @@ export default function ConsulterMissionEngagementPage({ missionEngagement }: Co
   return (
     <>
       <HeadTag title={`${missionEngagement.titre} | 1jeune1solution`} />
-      <ConsulterMissionEngagement missionEngagement={ missionEngagement } />
+      <ConsulterMissionEngagement missionEngagement={missionEngagement} />
     </>
   );
 }
@@ -43,12 +45,5 @@ export async function getStaticProps(context: GetStaticPropsContext<MissionConte
       missionEngagement: JSON.parse(JSON.stringify(missionEngagement.result)),
     },
     revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
-  };
-}
-
-export async function getStaticPaths(): Promise<GetStaticPathsResult> {
-  return {
-    fallback: true,
-    paths: [],
   };
 }

--- a/src/pages/decouvrir-les-metiers/[id].tsx
+++ b/src/pages/decouvrir-les-metiers/[id].tsx
@@ -1,4 +1,4 @@
-import { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import { GetStaticPropsContext, GetStaticPropsResult } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import React from 'react';
 
@@ -69,12 +69,5 @@ export async function getStaticProps(context: GetStaticPropsContext<FicheMetierC
       ficheMetier: JSON.parse(JSON.stringify(response.result)),
     },
     revalidate: 86400,
-  };
-}
-
-export async function getStaticPaths(): Promise<GetStaticPathsResult> {
-  return {
-    fallback: true,
-    paths: [],
   };
 }

--- a/src/pages/emplois/[id].tsx
+++ b/src/pages/emplois/[id].tsx
@@ -1,4 +1,4 @@
-import { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import { GetStaticPropsContext, GetStaticPropsResult } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import React from 'react';
 
@@ -43,12 +43,5 @@ export async function getStaticProps(context: GetStaticPropsContext<EmploiContex
       offreEmploi: JSON.parse(JSON.stringify(offreEmploi.result)),
     },
     revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
-  };
-}
-
-export async function getStaticPaths(): Promise<GetStaticPathsResult> {
-  return {
-    fallback: true,
-    paths: [],
   };
 }

--- a/src/pages/jobs-etudiants/[id].tsx
+++ b/src/pages/jobs-etudiants/[id].tsx
@@ -1,4 +1,4 @@
-import { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import { GetStaticPropsContext, GetStaticPropsResult } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import React from 'react';
 
@@ -43,12 +43,5 @@ export async function getStaticProps(context: GetStaticPropsContext<EmploiContex
       jobEtudiant: JSON.parse(JSON.stringify(offreEmploi.result)),
     },
     revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
-  };
-}
-
-export async function getStaticPaths(): Promise<GetStaticPathsResult> {
-  return {
-    fallback: true,
-    paths: [],
   };
 }

--- a/src/pages/service-civique/[id].tsx
+++ b/src/pages/service-civique/[id].tsx
@@ -1,8 +1,10 @@
-import { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import { GetStaticPropsContext, GetStaticPropsResult } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import React from 'react';
 
-import { ConsulterMissionEngagement } from '~/client/components/features/Engagement/Consulter/ConsulterMissionEngagement';
+import {
+  ConsulterMissionEngagement,
+} from '~/client/components/features/Engagement/Consulter/ConsulterMissionEngagement';
 import { HeadTag } from '~/client/components/utils/HeaderTag';
 import { Mission, MissionId } from '~/server/engagement/domain/engagement';
 import { PageContextParamsException } from '~/server/exceptions/pageContextParams.exception';
@@ -43,12 +45,5 @@ export async function getStaticProps(context: GetStaticPropsContext<MissionConte
       missionEngagement: JSON.parse(JSON.stringify(missionEngagement.result)),
     },
     revalidate: dependencies.cmsDependencies.duréeDeValiditéEnSecondes(),
-  };
-}
-
-export async function getStaticPaths(): Promise<GetStaticPathsResult> {
-  return {
-    fallback: true,
-    paths: [],
   };
 }


### PR DESCRIPTION
Après le message de Paulo le biscoto sur le mattermost on a remarqué que dans le code on faisait des trucs pas utiliser par le framework.

https://nextjs.org/docs/basic-features/data-fetching/get-static-paths

Le `getStaticPaths` ne sert que pour prégénérer au build une liste de page qu'on lui passe dans le `paths`. Comme on connait la liste de page a prégénérer pas besoin de ce paramètre.

Right, on vire tout ca ?