### PR TITLE
feat(pole emploi): gestion des erreurs

### DIFF
--- a/src/server/alternances/infra/repositories/apiPoleEmploiAlternance.repository.ts
+++ b/src/server/alternances/infra/repositories/apiPoleEmploiAlternance.repository.ts
@@ -12,6 +12,7 @@ import {
   mapOffre,
   mapRésultatsRechercheOffre,
 } from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploi.mapper';
+import { handleSearchFailureError } from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError';
 import {
   OffreResponse,
   RésultatsRechercheOffreResponse,
@@ -65,8 +66,7 @@ export class ApiPoleEmploiAlternanceRepository implements OffreRepository {
         }
         return createSuccess(mapRésultatsRechercheOffre(response.data));
       } catch (e) {
-        LoggerService.error('[API Pole Emploi] impossible de rechercher');
-        return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+        return handleSearchFailureError(e);
       }
 
     }

--- a/src/server/alternances/infra/repositories/apiPoleEmploiAlternance.repository.ts
+++ b/src/server/alternances/infra/repositories/apiPoleEmploiAlternance.repository.ts
@@ -11,7 +11,6 @@ import { OffreRepository } from '~/server/offres/domain/offre.repository';
 import {
   mapOffre,
   mapRésultatsRechercheOffre,
-  mapRésultatsRechercheOffreResponse,
 } from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploi.mapper';
 import {
   OffreResponse,
@@ -23,6 +22,7 @@ import {
 } from '~/server/offres/infra/repositories/pole-emploi/poleEmploiParamètreBuilder.service';
 import { CacheService } from '~/server/services/cache/cache.service';
 import { HttpClientServiceWithAuthentification } from '~/server/services/http/httpClientWithAuthentification.service';
+import { LoggerService } from '~/server/services/logger.service';
 
 export class ApiPoleEmploiAlternanceRepository implements OffreRepository {
   constructor(
@@ -36,10 +36,16 @@ export class ApiPoleEmploiAlternanceRepository implements OffreRepository {
   private ECHANTILLON_OFFRE_ALTERNANCE_KEY = 'ECHANTILLON_OFFRE_ALTERNANCE_KEY';
 
   async get(id: OffreId): Promise<Either<Offre>> {
-    return this.httpClientServiceWithAuthentification.get<OffreResponse, Offre>(
-      `/${id}`,
-      mapOffre,
-    );
+    try {
+      const response = await this.httpClientServiceWithAuthentification.get<OffreResponse>(`/${id}`);
+      if(response.status === 204) {
+        return createFailure(ErreurMétier.CONTENU_INDISPONIBLE);
+      }
+      return createSuccess(mapOffre(response.data));
+    } catch (e) {
+      LoggerService.error('[API Pole Emploi] impossible de récupérer la ressource');
+      return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+    }
   }
 
   async search(offreFiltre: OffreFiltre): Promise<Either<RésultatsRechercheOffre>> {
@@ -50,10 +56,19 @@ export class ApiPoleEmploiAlternanceRepository implements OffreRepository {
   private async getOffreAlternanceRecherche(offreFiltre: OffreFiltre) {
     const paramètresRecherche = await this.poleEmploiParamètreBuilderService.buildCommonParamètresRecherche(offreFiltre);
     if(paramètresRecherche) {
-      return this.httpClientServiceWithAuthentification.get<RésultatsRechercheOffreResponse, RésultatsRechercheOffre>(
-        `/search?${paramètresRecherche}&${this.paramètreParDéfaut}`,
-        mapRésultatsRechercheOffre,
-      );
+      try {
+        const response = await this.httpClientServiceWithAuthentification.get<RésultatsRechercheOffreResponse>(
+          `/search?${paramètresRecherche}&${this.paramètreParDéfaut}`,
+        );
+        if(response.status === 204) {
+          return createSuccess({ nombreRésultats: 0, résultats: [] });
+        }
+        return createSuccess(mapRésultatsRechercheOffre(response.data));
+      } catch (e) {
+        LoggerService.error('[API Pole Emploi] impossible de rechercher');
+        return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+      }
+
     }
     return createFailure(ErreurMétier.DEMANDE_INCORRECTE);
   }
@@ -62,18 +77,18 @@ export class ApiPoleEmploiAlternanceRepository implements OffreRepository {
     const responseInCache = await this.cacheService.get<RésultatsRechercheOffreResponse>(this.ECHANTILLON_OFFRE_ALTERNANCE_KEY);
     const range = buildRangeParamètre(offreFiltre);
 
-    if (responseInCache) return createSuccess(mapRésultatsRechercheOffre(responseInCache));
-    else {
-      const response =  await this.httpClientServiceWithAuthentification.get<RésultatsRechercheOffreResponse, RésultatsRechercheOffreResponse>(
-        `/search?range=${range}&${this.paramètreParDéfaut}`,
-        mapRésultatsRechercheOffreResponse,
-      );
-      switch (response.instance) {
-        case 'success': {
-          this.cacheService.set(this.ECHANTILLON_OFFRE_ALTERNANCE_KEY, response.result, 24);
-          return createSuccess(mapRésultatsRechercheOffre(response.result));
-        }
-        case 'failure': return createFailure(ErreurMétier.DEMANDE_INCORRECTE);
+    if (responseInCache) {
+      return createSuccess(mapRésultatsRechercheOffre(responseInCache));
+    } else {
+      try {
+        const response = await this.httpClientServiceWithAuthentification.get<RésultatsRechercheOffreResponse>(
+          `/search?range=${range}&${this.paramètreParDéfaut}`,
+        );
+        this.cacheService.set(this.ECHANTILLON_OFFRE_ALTERNANCE_KEY, response.data, 24);
+        return createSuccess(mapRésultatsRechercheOffre(response.data));
+      } catch (e) {
+        LoggerService.error('[API Pole Emploi] impossible de rechercher');
+        return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
       }
     }
   }

--- a/src/server/demande-de-contact/infra/strapiDemandeDeContact.repository.ts
+++ b/src/server/demande-de-contact/infra/strapiDemandeDeContact.repository.ts
@@ -1,18 +1,18 @@
 import { createFailure, createSuccess, Either } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
+import { HttpClientServiceWithAuthentification } from '~/server/services/http/httpClientWithAuthentification.service';
 
-import { OldHttpClientService } from '../../services/http/oldHttpClientService';
 import { DemandeDeContactCEJ, DemandeDeContactEntreprise } from '../domain/DemandeDeContact';
 import { DemandeDeContactRepository } from '../domain/DemandeDeContact.repository';
 
 export class StrapiDemandeDeContactRepository implements DemandeDeContactRepository {
 
-  constructor(private httpClientService: OldHttpClientService) {
+  constructor(private httpClientServiceWithAuthentification: HttpClientServiceWithAuthentification) {
   }
 
   async saveCEJ(demandeDeContactCEJ: DemandeDeContactCEJ): Promise<Either<void>> {
     try {
-      await this.httpClientService.post('contact-cejs', {
+      await this.httpClientServiceWithAuthentification.post('contact-cejs', {
         data: {
           age: demandeDeContactCEJ.age,
           code_postal: demandeDeContactCEJ.codePostal,
@@ -31,7 +31,7 @@ export class StrapiDemandeDeContactRepository implements DemandeDeContactReposit
 
   async saveEntreprise(demandeDeContactEntreprise: DemandeDeContactEntreprise): Promise<Either<void>> {
     try {
-      await this.httpClientService.post('contact-entreprises', {
+      await this.httpClientServiceWithAuthentification.post('contact-entreprises', {
         data: {
           email: demandeDeContactEntreprise.email,
           message: demandeDeContactEntreprise.message,

--- a/src/server/emplois/infra/repositories/apiPoleEmploiOffre.repository.ts
+++ b/src/server/emplois/infra/repositories/apiPoleEmploiOffre.repository.ts
@@ -7,6 +7,7 @@ import {
   mapOffre,
   mapRésultatsRechercheOffre,
 } from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploi.mapper';
+import { handleSearchFailureError } from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError';
 import {
   OffreResponse,
   RésultatsRechercheOffreResponse,
@@ -78,8 +79,7 @@ export class ApiPoleEmploiOffreRepository implements OffreRepository {
         }
         return createSuccess(mapRésultatsRechercheOffre(response.data));
       } catch (e) {
-        LoggerService.error('[API Pole Emploi] impossible de rechercher');
-        return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+        return handleSearchFailureError(e);
       }
     }
     return createFailure(ErreurMétier.DEMANDE_INCORRECTE);

--- a/src/server/entreprises/infra/strapiRejoindreLaMobilisation.repository.ts
+++ b/src/server/entreprises/infra/strapiRejoindreLaMobilisation.repository.ts
@@ -1,13 +1,13 @@
 import { createFailure, createSuccess, Either } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
+import { HttpClientServiceWithAuthentification } from '~/server/services/http/httpClientWithAuthentification.service';
 
-import { OldHttpClientService } from '../../services/http/oldHttpClientService';
 import { Entreprise } from '../domain/Entreprise';
 import { RejoindreLaMobilisationRepository } from '../domain/RejoindreLaMobilisation.repository';
 
 export class StrapiRejoindreLaMobilisationRepository implements RejoindreLaMobilisationRepository {
 
-  constructor(private httpClientService: OldHttpClientService) {
+  constructor(private httpClientService: HttpClientServiceWithAuthentification) {
   }
   async save(entreprise: Entreprise, annotation?: string): Promise<Either<void>> {
     try {

--- a/src/server/jobs-étudiants/infra/repositories/apiPoleEmploiJobÉtudiant.repository.ts
+++ b/src/server/jobs-étudiants/infra/repositories/apiPoleEmploiJobÉtudiant.repository.ts
@@ -6,7 +6,6 @@ import { OffreRepository } from '~/server/offres/domain/offre.repository';
 import {
   mapOffre,
   mapRésultatsRechercheOffre,
-  mapRésultatsRechercheOffreResponse,
 } from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploi.mapper';
 import {
   OffreResponse,
@@ -18,6 +17,7 @@ import {
 } from '~/server/offres/infra/repositories/pole-emploi/poleEmploiParamètreBuilder.service';
 import { CacheService } from '~/server/services/cache/cache.service';
 import { HttpClientServiceWithAuthentification } from '~/server/services/http/httpClientWithAuthentification.service';
+import { LoggerService } from '~/server/services/logger.service';
 import { removeUndefinedValueInQueryParameterList } from '~/server/services/utils/urlParams.util';
 
 export class ApiPoleEmploiJobÉtudiantRepository implements OffreRepository {
@@ -33,10 +33,16 @@ export class ApiPoleEmploiJobÉtudiantRepository implements OffreRepository {
   private ECHANTILLON_OFFRE_JOB_ETUDIANT_KEY = 'ECHANTILLON_OFFRE_JOB_ETUDIANT_KEY';
 
   async get(id: OffreId): Promise<Either<Offre>> {
-    return this.httpClientServiceWithAuthentification.get<OffreResponse, Offre>(
-      `/${id}`,
-      mapOffre,
-    );
+    try {
+      const response = await this.httpClientServiceWithAuthentification.get<OffreResponse>(`/${id}`);
+      if(response.status === 204) {
+        return createFailure(ErreurMétier.CONTENU_INDISPONIBLE);
+      }
+      return createSuccess(mapOffre(response.data));
+    } catch (e) {
+      LoggerService.error('[API Pole Emploi] impossible de récupérer la ressource');
+      return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+    }
   }
 
   async search(jobÉtudiantFiltre: JobÉtudiantFiltre): Promise<Either<RésultatsRechercheOffre>> {
@@ -60,10 +66,18 @@ export class ApiPoleEmploiJobÉtudiantRepository implements OffreRepository {
     const paramètresRecherche = await this.poleEmploiParamètreBuilderService.buildCommonParamètresRecherche(jobÉtudiantFiltre);
     const jobÉtudiantParamètresRecherche = await this.buildJobÉtudiantParamètresRecherche(jobÉtudiantFiltre);
     if(paramètresRecherche) {
-      return this.httpClientServiceWithAuthentification.get<RésultatsRechercheOffreResponse, RésultatsRechercheOffre>(
-        `/search?${paramètresRecherche}&${jobÉtudiantParamètresRecherche}&${this.paramètreParDéfaut}`,
-        mapRésultatsRechercheOffre,
-      );
+      try {
+        const response = await this.httpClientServiceWithAuthentification.get<RésultatsRechercheOffreResponse>(
+          `/search?${paramètresRecherche}&${jobÉtudiantParamètresRecherche}&${this.paramètreParDéfaut}`,
+        );
+        if(response.status === 204) {
+          return createSuccess({ nombreRésultats: 0, résultats: [] });
+        }
+        return createSuccess(mapRésultatsRechercheOffre(response.data));
+      } catch (e) {
+        LoggerService.error('[API Pole Emploi] impossible de rechercher');
+        return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+      }
     }
     return createFailure(ErreurMétier.DEMANDE_INCORRECTE);
   }
@@ -72,18 +86,18 @@ export class ApiPoleEmploiJobÉtudiantRepository implements OffreRepository {
     const responseInCache = await this.cacheService.get<RésultatsRechercheOffreResponse>(this.ECHANTILLON_OFFRE_JOB_ETUDIANT_KEY);
     const range = buildRangeParamètre(jobÉtudiantFiltre);
 
-    if (responseInCache) return createSuccess(mapRésultatsRechercheOffre(responseInCache));
-    else {
-      const response =  await this.httpClientServiceWithAuthentification.get<RésultatsRechercheOffreResponse, RésultatsRechercheOffreResponse>(
-        `/search?range=${range}&${this.paramètreParDéfaut}`,
-        mapRésultatsRechercheOffreResponse,
-      );
-      switch (response.instance) {
-        case 'success': {
-          this.cacheService.set(this.ECHANTILLON_OFFRE_JOB_ETUDIANT_KEY, response.result, 24);
-          return createSuccess(mapRésultatsRechercheOffre(response.result));
-        }
-        case 'failure': return createFailure(ErreurMétier.DEMANDE_INCORRECTE);
+    if (responseInCache) {
+      return createSuccess(mapRésultatsRechercheOffre(responseInCache));
+    } else {
+      try {
+        const response = await this.httpClientServiceWithAuthentification.get<RésultatsRechercheOffreResponse>(
+          `/search?range=${range}&${this.paramètreParDéfaut}`,
+        );
+        this.cacheService.set(this.ECHANTILLON_OFFRE_JOB_ETUDIANT_KEY, response.data, 24);
+        return createSuccess(mapRésultatsRechercheOffre(response.data));
+      } catch (e) {
+        LoggerService.error('[API Pole Emploi] impossible de rechercher');
+        return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
       }
     }
   }

--- a/src/server/jobs-étudiants/infra/repositories/apiPoleEmploiJobÉtudiant.repository.ts
+++ b/src/server/jobs-étudiants/infra/repositories/apiPoleEmploiJobÉtudiant.repository.ts
@@ -7,6 +7,7 @@ import {
   mapOffre,
   mapRésultatsRechercheOffre,
 } from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploi.mapper';
+import { handleSearchFailureError } from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError';
 import {
   OffreResponse,
   RésultatsRechercheOffreResponse,
@@ -75,8 +76,7 @@ export class ApiPoleEmploiJobÉtudiantRepository implements OffreRepository {
         }
         return createSuccess(mapRésultatsRechercheOffre(response.data));
       } catch (e) {
-        LoggerService.error('[API Pole Emploi] impossible de rechercher');
-        return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+        return handleSearchFailureError(e);
       }
     }
     return createFailure(ErreurMétier.DEMANDE_INCORRECTE);

--- a/src/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError.ts
+++ b/src/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError.ts
@@ -1,0 +1,37 @@
+import axios, { AxiosError } from 'axios';
+
+import { createFailure } from '~/server/errors/either';
+import { ErreurMétier } from '~/server/errors/erreurMétier.types';
+import { LoggerService } from '~/server/services/logger.service';
+
+export interface ApiPoleEmploiErrorResponse {
+  message: string
+}
+
+export const errorFromApiPoleEmploi = [
+  'Format du paramètre « motsCles » incorrect. 7 mots-clé au maximum séparés par des virgules et d\'au moins 2 caractères.',
+  'La plage de résultats demandée est trop importante.',
+  'Format du paramètre « range » incorrect. <entier>-<entier> attendu.',
+  'Valeur du paramètre « natureContrat » incorrecte.',
+  'Valeur du paramètre « typeContrat » incorrecte.',
+  'Valeur du paramètre « departement » incorrecte.',
+  'Valeur du paramètre « commune » incorrecte.',
+  'Valeur du paramètre « region » incorrecte.',
+  'Format du paramètre « tempsPlein » incorrect. Booléen attendu.',
+  'Format du paramètre « grandDomaine » incorrect. A, B, C, C15, D, E, F, G, H, I, J, K, L, L14, M15, M18, M, M16, M17, M13, M14 ou N attendu.',
+  'Format du paramètre « experienceExigence » incorrect. D, E ou S attendu.',
+];
+
+export function handleSearchFailureError(e: unknown) {
+  if (axios.isAxiosError(e)) {
+    const error: AxiosError<ApiPoleEmploiErrorResponse> = e as AxiosError<ApiPoleEmploiErrorResponse>;
+    if(error.response?.status === 400 && errorFromApiPoleEmploi.includes(e.response?.data.message)) {
+      return createFailure(ErreurMétier.DEMANDE_INCORRECTE);
+    } else {
+      LoggerService.warn('[API Pole Emploi] recherche incorrecte');
+      return createFailure(ErreurMétier.DEMANDE_INCORRECTE);
+    }
+  }
+  LoggerService.error('[API Pole Emploi] impossible de rechercher');
+  return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+}

--- a/src/server/offres/infra/repositories/pole-emploi/apiPoleEmploiRéférentiel.repository.ts
+++ b/src/server/offres/infra/repositories/pole-emploi/apiPoleEmploiRéférentiel.repository.ts
@@ -16,17 +16,9 @@ export class ApiPoleEmploiRéférentielRepository {
     if(responseInCache) {
       return mapCodeInsee(responseInCache, code);
     } else {
-      const response = await this.httpClientServiceWithAuthentification.get<RésultatsRéférentielCommunesResponse[], RésultatsRéférentielCommunesResponse[]>(
-        '/communes',
-        (data) => data,
-      );
-      switch (response.instance) {
-        case 'success': {
-          this.cacheService.set(this.CACHE_KEY, response.result, 24);
-          return mapCodeInsee(response.result, code);
-        }
-        case 'failure': return code;
-      }
+      const response = await this.httpClientServiceWithAuthentification.get<RésultatsRéférentielCommunesResponse[]>('/communes');
+      this.cacheService.set(this.CACHE_KEY, response.data, 24);
+      return mapCodeInsee(response.data, code);
     }
   };
 }

--- a/src/server/services/http/httpClientService.ts
+++ b/src/server/services/http/httpClientService.ts
@@ -21,4 +21,8 @@ export class HttpClientService {
   async post<Body>(endpoint: string, body: Body) {
     return this.client.post(endpoint, body);
   }
+
+  protected setAuthorizationHeader(token: string): void {
+    this.client.defaults.headers.common.Authorization = `Bearer ${token}`;
+  }
 }

--- a/tests/fixtures/services/poleEmploiHttpClientService.fixture.ts
+++ b/tests/fixtures/services/poleEmploiHttpClientService.fixture.ts
@@ -21,7 +21,7 @@ export function aRésultatRechercheOffreEmploiAxiosResponse(override?: Partial<R
   return anAxiosResponse({
     filtresPossibles: aFiltresPossiblesResponse(),
     resultats: [
-      aBarmanOffreEmploiResponse(),
+      aBarmanOffreEmploiApiResponse(),
       aMaçonOffreEmploiResponse(),
       aValetOffreEmploiResponse(),
     ],
@@ -29,11 +29,11 @@ export function aRésultatRechercheOffreEmploiAxiosResponse(override?: Partial<R
   });
 }
 
-export function aRésultatsRechercheOffreEmploiResponse() {
+export function aRésultatsRechercheOffreEmploiApiResponse() {
   return {
     filtresPossibles: aFiltresPossiblesResponse(),
     resultats: [
-      aBarmanOffreEmploiResponse(),
+      aBarmanOffreEmploiApiResponse(),
       aMaçonOffreEmploiResponse(),
       aValetOffreEmploiResponse(),
     ],
@@ -68,11 +68,7 @@ export function aRésultatRéférentielCommuneResponse() {
   ]);
 }
 
-export function aBarmanOffreEmploiAxiosResponse(): AxiosResponse<OffreResponse> {
-  return anAxiosResponse(aBarmanOffreEmploiResponse());
-}
-
-function aBarmanOffreEmploiResponse(): OffreResponse {
+export function aBarmanOffreEmploiApiResponse(): OffreResponse {
   return {
     description: 'Nous recherchons pour la saison demi-mai à mi-octobre 2022 un(e) Barman h/f.\n\nVos missions principales: \n- Vous effectuez le service au comptoir, en salle, en terrasse, de boissons chaudes ou froides selon la législation relative à la consommation d\'alcools. \n- Vous entretenez la verrerie, les équipements du bar et les locaux selon les règles d\'hygiène et la réglementation  en vigueur.\n- Vous participez à la vie de la paillote. \n \nVous travaillez vendredi et samedi. \n\n\n',
     dureeTravailLibelleConverti: 'Temps partiel',

--- a/tests/fixtures/services/strapiHttpClientService.fixture.ts
+++ b/tests/fixtures/services/strapiHttpClientService.fixture.ts
@@ -1,13 +1,13 @@
 import { anAxiosInstance } from '@tests/fixtures/services/httpClientService.fixture';
 
-import { HttpClientService } from '~/server/services/http/httpClientService';
+import { HttpClientServiceWithAuthentification } from '~/server/services/http/httpClientWithAuthentification.service';
 
-export function aStrapiHttpClientService(): HttpClientService {
+export function aStrapiHttpClientService(): HttpClientServiceWithAuthentification {
   return {
     client: anAxiosInstance(),
     get: jest.fn(),
     post: jest.fn(),
     refreshToken: jest.fn(),
     setAuthorizationHeader: jest.fn(),
-  } as unknown as HttpClientService;
+  } as unknown as HttpClientServiceWithAuthentification;
 }

--- a/tests/pages/api/alternances/index.test.ts
+++ b/tests/pages/api/alternances/index.test.ts
@@ -1,4 +1,5 @@
 import { aRésultatsRechercheOffre } from '@tests/fixtures/domain/offre.fixture';
+import { anAxiosError, anAxiosResponse } from '@tests/fixtures/services/httpClientService.fixture';
 import {
   aRésultatRechercheOffreEmploiAxiosResponse,
   aRésultatRéférentielCommuneResponse,
@@ -15,7 +16,7 @@ describe('rechercher une alternance', () => {
   it('retourne la liste des alternances filtrée', async () => {
     nock('https://api.emploi-store.fr/partenaire/offresdemploi/v2/offres')
       .get('/search?commune=75101&motsCles=boulanger&range=0-14&natureContrat=E2,FS')
-      .reply(401)
+      .reply(401, anAxiosError({ response: anAxiosResponse({}, 401) }))
       .get('/search?commune=75101&motsCles=boulanger&range=0-14&natureContrat=E2,FS')
       .reply(200, aRésultatRechercheOffreEmploiAxiosResponse().data);
 

--- a/tests/server/alternances/infra/repositories/apiPoleEmploiAlternance.repository.test.ts
+++ b/tests/server/alternances/infra/repositories/apiPoleEmploiAlternance.repository.test.ts
@@ -1,29 +1,26 @@
 import {
   aBarmanOffre,
+  anOffreÉchantillonAvecLocalisationEtMotCléFiltre,
   anOffreÉchantillonFiltre,
   anOffreEmploiFiltre,
-  aRésultatsRechercheOffre,
-} from '@tests/fixtures/domain/offre.fixture';
+  aRésultatsRechercheOffre } from '@tests/fixtures/domain/offre.fixture';
 import {
   aPoleEmploiParamètreBuilderService,
 } from '@tests/fixtures/server/offresEmploi/poleEmploiParamètreBuilder.service.fixture';
 import { MockedCacheService } from '@tests/fixtures/services/cacheService.fixture';
+import { anAxiosResponse } from '@tests/fixtures/services/httpClientService.fixture';
 import {
+  aBarmanOffreEmploiApiResponse,
   aPoleEmploiHttpClient,
-  aRésultatsRechercheOffreEmploiResponse,
+  aRésultatsRechercheOffreEmploiApiResponse,
 } from '@tests/fixtures/services/poleEmploiHttpClientService.fixture';
 
 import {
   ApiPoleEmploiAlternanceRepository,
 } from '~/server/alternances/infra/repositories/apiPoleEmploiAlternance.repository';
-import { createSuccess, Failure, Success } from '~/server/errors/either';
+import { Failure, Success } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { Offre, RésultatsRechercheOffre } from '~/server/offres/domain/offre';
-import {
-  mapOffre,
-  mapRésultatsRechercheOffre,
-  mapRésultatsRechercheOffreResponse,
-} from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploi.mapper';
 import {
   PoleEmploiParamètreBuilderService,
 } from '~/server/offres/infra/repositories/pole-emploi/poleEmploiParamètreBuilder.service';
@@ -48,7 +45,7 @@ describe('ApiPoleEmploiAlternanceRepository', () => {
       it('récupère l’offre d’alternance selon l’id', async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aBarmanOffre()));
+          .mockResolvedValue(anAxiosResponse(aBarmanOffreEmploiApiResponse()));
         const expected = aBarmanOffre();
         const offreEmploiId = expected.id;
 
@@ -57,7 +54,6 @@ describe('ApiPoleEmploiAlternanceRepository', () => {
         expect(result).toEqual(expected);
         expect(httpClientServiceWithAuthentification.get).toHaveBeenCalledWith(
           '/132LKFB',
-          mapOffre,
         );
       });
     });
@@ -69,7 +65,7 @@ describe('ApiPoleEmploiAlternanceRepository', () => {
         it("fait l'appel à l'api et set les informations dans le cache", async () => {
           jest
             .spyOn(httpClientServiceWithAuthentification, 'get')
-            .mockResolvedValue(createSuccess(aRésultatsRechercheOffreEmploiResponse()));
+            .mockResolvedValue(anAxiosResponse(aRésultatsRechercheOffreEmploiApiResponse()));
 
           jest
             .spyOn(poleEmploiParamètreBuilderService, 'buildCommonParamètresRecherche')
@@ -87,16 +83,15 @@ describe('ApiPoleEmploiAlternanceRepository', () => {
           expect(result).toEqual(aRésultatsRechercheOffre());
           expect(httpClientServiceWithAuthentification.get).toHaveBeenCalledWith(
             '/search?range=0-14&natureContrat=E2,FS',
-            mapRésultatsRechercheOffreResponse,
           );
 
-          expect(cacheService.set).toHaveBeenCalledWith('ECHANTILLON_OFFRE_ALTERNANCE_KEY', aRésultatsRechercheOffreEmploiResponse(), 24);
+          expect(cacheService.set).toHaveBeenCalledWith('ECHANTILLON_OFFRE_ALTERNANCE_KEY', aRésultatsRechercheOffreEmploiApiResponse(), 24);
         });
       });
 
       describe('quand les informations sont déjà en cache', () => {
         it("ne fait pas l'appel à l'api et get les informations du cache", async () => {
-          jest.spyOn(cacheService, 'get').mockResolvedValue(aRésultatsRechercheOffreEmploiResponse());
+          jest.spyOn(cacheService, 'get').mockResolvedValue(aRésultatsRechercheOffreEmploiApiResponse());
           jest.spyOn(cacheService, 'set');
 
           const offreFiltre = anOffreÉchantillonFiltre();
@@ -110,7 +105,6 @@ describe('ApiPoleEmploiAlternanceRepository', () => {
 
           expect(cacheService.set).not.toHaveBeenCalled();
         });
-
       });
     });
 
@@ -118,9 +112,9 @@ describe('ApiPoleEmploiAlternanceRepository', () => {
       it("ne get pas les informations du cache et fait appel à l'api avec les filtres", async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aRésultatsRechercheOffre()));
+          .mockResolvedValue(anAxiosResponse(aRésultatsRechercheOffreEmploiApiResponse()));
 
-        jest.spyOn(cacheService, 'get').mockResolvedValue(aRésultatsRechercheOffreEmploiResponse());
+        jest.spyOn(cacheService, 'get').mockResolvedValue(aRésultatsRechercheOffreEmploiApiResponse());
         jest.spyOn(cacheService, 'set');
 
         const offreFiltre = anOffreEmploiFiltre();
@@ -153,7 +147,7 @@ describe('ApiPoleEmploiAlternanceRepository', () => {
       it('recherche les offres d’alternance de pole emploi', async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aRésultatsRechercheOffre()));
+          .mockResolvedValue(anAxiosResponse(aRésultatsRechercheOffreEmploiApiResponse()));
         jest
           .spyOn(poleEmploiParamètreBuilderService, 'buildCommonParamètresRecherche')
           .mockResolvedValue('region=34&motsCles=boulanger&range=0-14');
@@ -164,8 +158,19 @@ describe('ApiPoleEmploiAlternanceRepository', () => {
         expect(result).toEqual(aRésultatsRechercheOffre());
         expect(httpClientServiceWithAuthentification.get).toHaveBeenCalledWith(
           '/search?region=34&motsCles=boulanger&range=0-14&natureContrat=E2,FS',
-          mapRésultatsRechercheOffre,
         );
+      });
+    });
+
+    describe('quand l’api renvoie une 204', () => {
+      it('retourne un success avec une liste vide', async () => {
+        jest
+          .spyOn(httpClientServiceWithAuthentification, 'get')
+          .mockResolvedValue(anAxiosResponse({}, 204));
+
+        const { result } = await apiPoleEmploiAlternanceRepository.search(anOffreÉchantillonAvecLocalisationEtMotCléFiltre()) as Success<RésultatsRechercheOffre>;
+
+        expect(result).toEqual({ nombreRésultats: 0, résultats: [] });
       });
     });
   });

--- a/tests/server/alternances/infra/repositories/apiPoleEmploiAlternance.repository.test.ts
+++ b/tests/server/alternances/infra/repositories/apiPoleEmploiAlternance.repository.test.ts
@@ -3,7 +3,8 @@ import {
   anOffreÉchantillonAvecLocalisationEtMotCléFiltre,
   anOffreÉchantillonFiltre,
   anOffreEmploiFiltre,
-  aRésultatsRechercheOffre } from '@tests/fixtures/domain/offre.fixture';
+  aRésultatsRechercheOffre,
+} from '@tests/fixtures/domain/offre.fixture';
 import {
   aPoleEmploiParamètreBuilderService,
 } from '@tests/fixtures/server/offresEmploi/poleEmploiParamètreBuilder.service.fixture';

--- a/tests/server/emplois/infra/repositories/apiPoleEmploiOffre.repository.test.ts
+++ b/tests/server/emplois/infra/repositories/apiPoleEmploiOffre.repository.test.ts
@@ -1,27 +1,24 @@
 import {
   aBarmanOffre,
+  anOffreÉchantillonAvecLocalisationEtMotCléFiltre,
   anOffreÉchantillonFiltre,
   anOffreEmploiFiltre,
-  aRésultatsRechercheOffre,
-} from '@tests/fixtures/domain/offre.fixture';
+  aRésultatsRechercheOffre } from '@tests/fixtures/domain/offre.fixture';
 import {
   aPoleEmploiParamètreBuilderService,
 } from '@tests/fixtures/server/offresEmploi/poleEmploiParamètreBuilder.service.fixture';
 import { MockedCacheService } from '@tests/fixtures/services/cacheService.fixture';
+import { anAxiosResponse } from '@tests/fixtures/services/httpClientService.fixture';
 import {
+  aBarmanOffreEmploiApiResponse,
   aPoleEmploiHttpClient,
-  aRésultatsRechercheOffreEmploiResponse,
+  aRésultatsRechercheOffreEmploiApiResponse,
 } from '@tests/fixtures/services/poleEmploiHttpClientService.fixture';
 
 import { ApiPoleEmploiOffreRepository } from '~/server/emplois/infra/repositories/apiPoleEmploiOffre.repository';
-import { createSuccess, Failure, Success } from '~/server/errors/either';
+import { Failure, Success } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { Offre, RésultatsRechercheOffre } from '~/server/offres/domain/offre';
-import {
-  mapOffre,
-  mapRésultatsRechercheOffre,
-  mapRésultatsRechercheOffreResponse,
-} from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploi.mapper';
 import {
   PoleEmploiParamètreBuilderService,
 } from '~/server/offres/infra/repositories/pole-emploi/poleEmploiParamètreBuilder.service';
@@ -46,7 +43,7 @@ describe('ApiPoleEmploiOffreRepository', () => {
       it('récupère l’offre d’emploi selon l’id', async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aBarmanOffre()));
+          .mockResolvedValue(anAxiosResponse(aBarmanOffreEmploiApiResponse()));
         const expected = aBarmanOffre();
         const offreEmploiId = expected.id;
 
@@ -55,7 +52,6 @@ describe('ApiPoleEmploiOffreRepository', () => {
         expect(result).toEqual(expected);
         expect(httpClientServiceWithAuthentification.get).toHaveBeenCalledWith(
           '/132LKFB',
-          mapOffre,
         );
       });
     });
@@ -67,7 +63,7 @@ describe('ApiPoleEmploiOffreRepository', () => {
         it("fait l'appel à l'api et set les informations dans le cache", async () => {
           jest
             .spyOn(httpClientServiceWithAuthentification, 'get')
-            .mockResolvedValue(createSuccess(aRésultatsRechercheOffreEmploiResponse()));
+            .mockResolvedValue(anAxiosResponse(aRésultatsRechercheOffreEmploiApiResponse()));
 
           jest
             .spyOn(poleEmploiParamètreBuilderService, 'buildCommonParamètresRecherche')
@@ -85,16 +81,15 @@ describe('ApiPoleEmploiOffreRepository', () => {
           expect(result).toEqual(aRésultatsRechercheOffre());
           expect(httpClientServiceWithAuthentification.get).toHaveBeenCalledWith(
             '/search?range=0-14&natureContrat=E1,FA,FJ,FT,FU,I1,NS,FV,FW,FX,FY,PS,PR,CC,CU,EE,ER,CI',
-            mapRésultatsRechercheOffreResponse,
           );
 
-          expect(cacheService.set).toHaveBeenCalledWith('ECHANTILLON_OFFRE_EMPLOI_KEY', aRésultatsRechercheOffreEmploiResponse(), 24);
+          expect(cacheService.set).toHaveBeenCalledWith('ECHANTILLON_OFFRE_EMPLOI_KEY', aRésultatsRechercheOffreEmploiApiResponse(), 24);
         });
       });
 
       describe('quand les informations sont déjà en cache', () => {
         it("ne fait pas l'appel à l'api et get les informations du cache", async () => {
-          jest.spyOn(cacheService, 'get').mockResolvedValue(aRésultatsRechercheOffreEmploiResponse());
+          jest.spyOn(cacheService, 'get').mockResolvedValue(aRésultatsRechercheOffreEmploiApiResponse());
           jest.spyOn(cacheService, 'set');
 
           const offreFiltre = anOffreÉchantillonFiltre();
@@ -116,9 +111,9 @@ describe('ApiPoleEmploiOffreRepository', () => {
       it("ne get pas les informations du cache et fait appel à l'api avec les filtres", async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aRésultatsRechercheOffre()));
+          .mockResolvedValue(anAxiosResponse(aRésultatsRechercheOffreEmploiApiResponse()));
 
-        jest.spyOn(cacheService, 'get').mockResolvedValue(aRésultatsRechercheOffreEmploiResponse());
+        jest.spyOn(cacheService, 'get').mockResolvedValue(aRésultatsRechercheOffreEmploiApiResponse());
         jest.spyOn(cacheService, 'set');
 
         const offreFiltre = anOffreEmploiFiltre();
@@ -151,7 +146,7 @@ describe('ApiPoleEmploiOffreRepository', () => {
       it('recherche les offres d’emploi de pole emploi', async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aRésultatsRechercheOffre()));
+          .mockResolvedValue(anAxiosResponse(aRésultatsRechercheOffreEmploiApiResponse()));
         jest
           .spyOn(poleEmploiParamètreBuilderService, 'buildCommonParamètresRecherche')
           .mockResolvedValue('region=34&motsCles=boulanger&range=0-14');
@@ -162,8 +157,19 @@ describe('ApiPoleEmploiOffreRepository', () => {
         expect(result).toEqual(aRésultatsRechercheOffre());
         expect(httpClientServiceWithAuthentification.get).toHaveBeenCalledWith(
           '/search?typeContrat=CDD%2CCDI&region=34&motsCles=boulanger&range=0-14',
-          mapRésultatsRechercheOffre,
         );
+      });
+    });
+
+    describe('quand l’api renvoie une 204', () => {
+      it('retourne un success avec une liste vide', async () => {
+        jest
+          .spyOn(httpClientServiceWithAuthentification, 'get')
+          .mockResolvedValue(anAxiosResponse({}, 204));
+
+        const { result } = await apiPoleEmploiOffreRepository.search(anOffreÉchantillonAvecLocalisationEtMotCléFiltre()) as Success<RésultatsRechercheOffre>;
+
+        expect(result).toEqual({ nombreRésultats: 0, résultats: [] });
       });
     });
   });

--- a/tests/server/emplois/infra/repositories/apiPoleEmploiOffre.repository.test.ts
+++ b/tests/server/emplois/infra/repositories/apiPoleEmploiOffre.repository.test.ts
@@ -3,7 +3,8 @@ import {
   anOffreÉchantillonAvecLocalisationEtMotCléFiltre,
   anOffreÉchantillonFiltre,
   anOffreEmploiFiltre,
-  aRésultatsRechercheOffre } from '@tests/fixtures/domain/offre.fixture';
+  aRésultatsRechercheOffre,
+} from '@tests/fixtures/domain/offre.fixture';
 import {
   aPoleEmploiParamètreBuilderService,
 } from '@tests/fixtures/server/offresEmploi/poleEmploiParamètreBuilder.service.fixture';

--- a/tests/server/emplois/infra/repositories/apiPoleEmploiRéférentiel.repository.test.ts
+++ b/tests/server/emplois/infra/repositories/apiPoleEmploiRéférentiel.repository.test.ts
@@ -2,9 +2,9 @@ import {
   aRésultatsRéférentielCommunesResponseList,
 } from '@tests/fixtures/server/offresEmploi/apiPoleEmploiRéférentiel.repository.fixture';
 import { MockedCacheService } from '@tests/fixtures/services/cacheService.fixture';
+import { anAxiosResponse } from '@tests/fixtures/services/httpClientService.fixture';
 import { aPoleEmploiHttpClient } from '@tests/fixtures/services/poleEmploiHttpClientService.fixture';
 
-import { createSuccess } from '~/server/errors/either';
 import {
   ApiPoleEmploiRéférentielRepository,
 } from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploiRéférentiel.repository';
@@ -33,7 +33,7 @@ describe('ApiPoleEmploiRéférentielRepository', () => {
       it('retourne le code insee', async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aRésultatsRéférentielCommunesResponseList()));
+          .mockResolvedValue(anAxiosResponse(aRésultatsRéférentielCommunesResponseList()));
         const expected = '55000';
 
         const result = await apiPoleEmploiRéférentielRepository.findCodeInseeInRéférentielCommune('55000');
@@ -46,7 +46,7 @@ describe('ApiPoleEmploiRéférentielRepository', () => {
       it('retourne le code passé en paramètre', async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aRésultatsRéférentielCommunesResponseList()));
+          .mockResolvedValue(anAxiosResponse(aRésultatsRéférentielCommunesResponseList()));
         const expected = '75999';
 
         const result = await apiPoleEmploiRéférentielRepository.findCodeInseeInRéférentielCommune('75999');
@@ -58,7 +58,7 @@ describe('ApiPoleEmploiRéférentielRepository', () => {
       it('retourne le code insee de paris 01', async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aRésultatsRéférentielCommunesResponseList()));
+          .mockResolvedValue(anAxiosResponse(aRésultatsRéférentielCommunesResponseList()));
         const expected = '75101';
 
         const result = await apiPoleEmploiRéférentielRepository.findCodeInseeInRéférentielCommune('75056');
@@ -71,7 +71,7 @@ describe('ApiPoleEmploiRéférentielRepository', () => {
       it('retourne le code insee de marseille 01', async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aRésultatsRéférentielCommunesResponseList()));
+          .mockResolvedValue(anAxiosResponse(aRésultatsRéférentielCommunesResponseList()));
         const expected = '13201';
 
         const result = await apiPoleEmploiRéférentielRepository.findCodeInseeInRéférentielCommune('13055');
@@ -84,7 +84,7 @@ describe('ApiPoleEmploiRéférentielRepository', () => {
       it('retourne le code insee de Lyon 01', async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aRésultatsRéférentielCommunesResponseList()));
+          .mockResolvedValue(anAxiosResponse(aRésultatsRéférentielCommunesResponseList()));
         const expected = '69381';
 
         const result = await apiPoleEmploiRéférentielRepository.findCodeInseeInRéférentielCommune('69123');

--- a/tests/server/entreprises/infra/strapiRejoindreLaMobilisation.repository.test.ts
+++ b/tests/server/entreprises/infra/strapiRejoindreLaMobilisation.repository.test.ts
@@ -1,14 +1,16 @@
-import { unContenuEntreprise, uneEntreprise } from '@tests/fixtures/client/services/lesEntreprisesSEngagentService.fixture';
+import {
+  unContenuEntreprise,
+  uneEntreprise,
+} from '@tests/fixtures/client/services/lesEntreprisesSEngagentService.fixture';
 import { Trap } from '@tests/fixtures/trap';
 import nock from 'nock';
 
 import {
   StrapiRejoindreLaMobilisationRepository,
 } from '~/server/entreprises/infra/strapiRejoindreLaMobilisation.repository';
-import { createFailure,createSuccess } from '~/server/errors/either';
+import { createFailure, createSuccess } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
-
-import { OldHttpClientService } from '../../../../src/server/services/http/oldHttpClientService';
+import { HttpClientServiceWithAuthentification } from '~/server/services/http/httpClientWithAuthentification.service';
 
 describe('StrapiRejoindreLaMobilisationRepository', () => {
   const entreprise = uneEntreprise();
@@ -19,9 +21,12 @@ describe('StrapiRejoindreLaMobilisationRepository', () => {
   const strapiUrl = 'http://strapi.local/api';
 
   describe('.save()', () => {
-    const client = new OldHttpClientService({
+    const client = new HttpClientServiceWithAuthentification({
       apiName: 'test strapi',
       apiUrl: strapiUrl,
+      tokenAgent: {
+        getToken: jest.fn(),
+      },
     });
     const repository = new StrapiRejoindreLaMobilisationRepository(client);
 
@@ -40,6 +45,7 @@ describe('StrapiRejoindreLaMobilisationRepository', () => {
       expect(strapi.isDone()).toBe(true);
       expect(bodyTrap.value()).toEqual(expectedBody);
     });
+
     it('résout un Success', async () => {
       // Given
       nock(strapiUrl)
@@ -50,6 +56,7 @@ describe('StrapiRejoindreLaMobilisationRepository', () => {
       // Then
       expect(result).toEqual(createSuccess(undefined));
     });
+
     describe('Quand il y a une annotation', () => {
       it('ajoute l\'annotation aux champs envoyés', async () => {
         // Given

--- a/tests/server/jobs-étudiants/infra/repositories/apiPoleEmploiJobÉtudiant.repository.test.ts
+++ b/tests/server/jobs-étudiants/infra/repositories/apiPoleEmploiJobÉtudiant.repository.test.ts
@@ -1,29 +1,26 @@
 import {
   aBarmanOffre,
+  anOffreÉchantillonAvecLocalisationEtMotCléFiltre,
   anOffreÉchantillonFiltre,
   anOffreEmploiFiltre,
-  aRésultatsRechercheOffre,
-} from '@tests/fixtures/domain/offre.fixture';
+  aRésultatsRechercheOffre } from '@tests/fixtures/domain/offre.fixture';
 import {
   aPoleEmploiParamètreBuilderService,
 } from '@tests/fixtures/server/offresEmploi/poleEmploiParamètreBuilder.service.fixture';
 import { MockedCacheService } from '@tests/fixtures/services/cacheService.fixture';
+import { anAxiosResponse } from '@tests/fixtures/services/httpClientService.fixture';
 import {
+  aBarmanOffreEmploiApiResponse,
   aPoleEmploiHttpClient,
-  aRésultatsRechercheOffreEmploiResponse,
+  aRésultatsRechercheOffreEmploiApiResponse,
 } from '@tests/fixtures/services/poleEmploiHttpClientService.fixture';
 
-import { createSuccess, Failure, Success } from '~/server/errors/either';
+import { Failure, Success } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import {
   ApiPoleEmploiJobÉtudiantRepository,
 } from '~/server/jobs-étudiants/infra/repositories/apiPoleEmploiJobÉtudiant.repository';
 import { Offre, RésultatsRechercheOffre } from '~/server/offres/domain/offre';
-import {
-  mapOffre,
-  mapRésultatsRechercheOffre,
-  mapRésultatsRechercheOffreResponse,
-} from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploi.mapper';
 import {
   PoleEmploiParamètreBuilderService,
 } from '~/server/offres/infra/repositories/pole-emploi/poleEmploiParamètreBuilder.service';
@@ -48,17 +45,14 @@ describe('ApiPoleEmploiJobÉtudiantRepository', () => {
       it('récupère l’offre de job étudiant selon l’id', async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aBarmanOffre()));
+          .mockResolvedValue(anAxiosResponse(aBarmanOffreEmploiApiResponse()));
         const expected = aBarmanOffre();
         const offreEmploiId = expected.id;
 
         const { result } = await apiPoleEmploiJobÉtudiantRepository.get(offreEmploiId) as Success<Offre>;
 
         expect(result).toEqual(expected);
-        expect(httpClientServiceWithAuthentification.get).toHaveBeenCalledWith(
-          '/132LKFB',
-          mapOffre,
-        );
+        expect(httpClientServiceWithAuthentification.get).toHaveBeenCalledWith('/132LKFB');
       });
     });
   });
@@ -69,7 +63,7 @@ describe('ApiPoleEmploiJobÉtudiantRepository', () => {
         it("fait l'appel à l'api et set les informations dans le cache", async () => {
           jest
             .spyOn(httpClientServiceWithAuthentification, 'get')
-            .mockResolvedValue(createSuccess(aRésultatsRechercheOffreEmploiResponse()));
+            .mockResolvedValue(anAxiosResponse(aRésultatsRechercheOffreEmploiApiResponse()));
 
           jest
             .spyOn(poleEmploiParamètreBuilderService, 'buildCommonParamètresRecherche')
@@ -85,18 +79,15 @@ describe('ApiPoleEmploiJobÉtudiantRepository', () => {
           expect(cacheService.get).toHaveBeenCalledWith('ECHANTILLON_OFFRE_JOB_ETUDIANT_KEY');
 
           expect(result).toEqual(aRésultatsRechercheOffre());
-          expect(httpClientServiceWithAuthentification.get).toHaveBeenCalledWith(
-            '/search?range=0-14&dureeHebdoMax=1600&tempsPlein=false&typeContrat=CDD,MIS,SAI',
-            mapRésultatsRechercheOffreResponse,
-          );
+          expect(httpClientServiceWithAuthentification.get).toHaveBeenCalledWith('/search?range=0-14&dureeHebdoMax=1600&tempsPlein=false&typeContrat=CDD,MIS,SAI');
 
-          expect(cacheService.set).toHaveBeenCalledWith('ECHANTILLON_OFFRE_JOB_ETUDIANT_KEY', aRésultatsRechercheOffreEmploiResponse(), 24);
+          expect(cacheService.set).toHaveBeenCalledWith('ECHANTILLON_OFFRE_JOB_ETUDIANT_KEY', aRésultatsRechercheOffreEmploiApiResponse(), 24);
         });
       });
 
       describe('quand les informations sont déjà en cache', () => {
         it("ne fait pas l'appel à l'api et get les informations du cache", async () => {
-          jest.spyOn(cacheService, 'get').mockResolvedValue(aRésultatsRechercheOffreEmploiResponse());
+          jest.spyOn(cacheService, 'get').mockResolvedValue(aRésultatsRechercheOffreEmploiApiResponse());
           jest.spyOn(cacheService, 'set');
 
           const offreFiltre = anOffreÉchantillonFiltre();
@@ -110,7 +101,6 @@ describe('ApiPoleEmploiJobÉtudiantRepository', () => {
 
           expect(cacheService.set).not.toHaveBeenCalled();
         });
-
       });
     });
 
@@ -118,9 +108,9 @@ describe('ApiPoleEmploiJobÉtudiantRepository', () => {
       it("ne get pas les informations du cache et fait appel à l'api avec les filtres", async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aRésultatsRechercheOffre()));
+          .mockResolvedValue(anAxiosResponse(aRésultatsRechercheOffreEmploiApiResponse()));
 
-        jest.spyOn(cacheService, 'get').mockResolvedValue(aRésultatsRechercheOffreEmploiResponse());
+        jest.spyOn(cacheService, 'get').mockResolvedValue(aRésultatsRechercheOffreEmploiApiResponse());
         jest.spyOn(cacheService, 'set');
 
         const offreFiltre = anOffreEmploiFiltre();
@@ -153,7 +143,7 @@ describe('ApiPoleEmploiJobÉtudiantRepository', () => {
       it('recherche les jobs étudiants de pole emploi', async () => {
         jest
           .spyOn(httpClientServiceWithAuthentification, 'get')
-          .mockResolvedValue(createSuccess(aRésultatsRechercheOffre()));
+          .mockResolvedValue(anAxiosResponse(aRésultatsRechercheOffreEmploiApiResponse()));
         jest
           .spyOn(poleEmploiParamètreBuilderService, 'buildCommonParamètresRecherche')
           .mockResolvedValue('region=34&motsCles=boulanger&range=0-14');
@@ -164,8 +154,19 @@ describe('ApiPoleEmploiJobÉtudiantRepository', () => {
         expect(result).toEqual(aRésultatsRechercheOffre());
         expect(httpClientServiceWithAuthentification.get).toHaveBeenCalledWith(
           '/search?region=34&motsCles=boulanger&range=0-14&&dureeHebdoMax=1600&tempsPlein=false&typeContrat=CDD,MIS,SAI',
-          mapRésultatsRechercheOffre,
         );
+      });
+    });
+
+    describe('quand l’api renvoie une 204', () => {
+      it('retourne un success avec une liste vide', async () => {
+        jest
+          .spyOn(httpClientServiceWithAuthentification, 'get')
+          .mockResolvedValue(anAxiosResponse({}, 204));
+
+        const { result } = await apiPoleEmploiJobÉtudiantRepository.search(anOffreÉchantillonAvecLocalisationEtMotCléFiltre()) as Success<RésultatsRechercheOffre>;
+
+        expect(result).toEqual({ nombreRésultats: 0, résultats: [] });
       });
     });
   });

--- a/tests/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError.test.ts
+++ b/tests/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError.test.ts
@@ -1,0 +1,43 @@
+import { Failure } from '../../../../../../src/server/errors/either';
+import { ErreurMétier } from '../../../../../../src/server/errors/erreurMétier.types';
+import {
+  errorFromApiPoleEmploi,
+  handleSearchFailureError,
+} from '../../../../../../src/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError';
+import { anAxiosError, anAxiosResponse } from '../../../../../fixtures/services/httpClientService.fixture';
+
+errorFromApiPoleEmploi.forEach((messageErrorFromApiPoleEmploi) => {
+  describe(`quand l’api renvoie une erreur 400 et le message d’erreur ${messageErrorFromApiPoleEmploi}`, () => {
+    it('retourne une failure demande incorrecte sans logger', async () => {
+      const error = anAxiosError({
+        response: anAxiosResponse(
+          {
+            message: messageErrorFromApiPoleEmploi,
+          },
+          400,
+        ),
+      });
+
+      const result = await handleSearchFailureError(error) as Failure;
+
+      expect(result.errorType).toEqual(ErreurMétier.DEMANDE_INCORRECTE);
+    });
+  });
+});
+
+describe('quand l’api renvoie une erreur 400 et un message inconnue', () => {
+  it('retourne une failure demande incorrecte en loggant', async () => {
+    const error = anAxiosError({
+      response: anAxiosResponse(
+        {
+          message: 'message inconnu',
+        },
+        400,
+      ),
+    });
+
+    const result = await handleSearchFailureError(error) as Failure;
+
+    expect(result.errorType).toEqual(ErreurMétier.DEMANDE_INCORRECTE);
+  });
+});

--- a/tests/server/services/http/httpClientWithAuthentification.service.test.ts
+++ b/tests/server/services/http/httpClientWithAuthentification.service.test.ts
@@ -1,8 +1,5 @@
-import chalk from 'chalk';
 import nock from 'nock';
 
-import { createFailure, createSuccess } from '~/server/errors/either';
-import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { HttpClientServiceWithAuthentification } from '~/server/services/http/httpClientWithAuthentification.service';
 
 describe('HttpClientServiceWithAuthentification', () => {
@@ -10,6 +7,7 @@ describe('HttpClientServiceWithAuthentification', () => {
     afterEach(() => {
       nock.cleanAll();
     });
+
     it('rafraichit un token quand il reçoit un 403', async () => {
       // Given
       const accessToken = 'uytrdxcvghfrtyh';
@@ -33,12 +31,13 @@ describe('HttpClientServiceWithAuthentification', () => {
 
 
       // When
-      const actual = await client.get('/test', (a) => a);
+      const actual = await client.get('/test', undefined);
       // Then
       miss.isDone();
       hit.isDone();
-      expect(actual).toEqual(createSuccess(body));
+      expect(actual.data).toEqual(body);
     });
+
     it('rafraichit un token quand il reçoit un 401', async () => {
       // Given
       const accessToken = 'uytrdxcvghfrtyh';
@@ -62,12 +61,13 @@ describe('HttpClientServiceWithAuthentification', () => {
 
 
       // When
-      const actual = await client.get('/test', (a) => a);
+      const actual = await client.get('/test', undefined);
       // Then
       miss.isDone();
       hit.isDone();
-      expect(actual).toEqual(createSuccess(body));
+      expect(actual.data).toEqual(body);
     });
+
     it('rafraichit un token qui a expiré', async () => {
       // Given
       const accessToken1 = 'uytrdxcvghfrtyh';
@@ -108,313 +108,16 @@ describe('HttpClientServiceWithAuthentification', () => {
 
 
       // When
-      const req1 = await client.get('/test', (a) => a);
-      const req2 = await client.get('/test', (a) => a);
+      const req1 = await client.get('/test', undefined);
+      const req2 = await client.get('/test', undefined);
       // Then
       miss.done();
       hit.done();
       expires.done();
       hitRefreshed.done();
-      expect(req1).toEqual(createSuccess(body));
-      expect(req2).toEqual(createSuccess(body));
+      expect(req1.data).toEqual(body);
+      expect(req2.data).toEqual(body);
       expect(tokenAgentStub.getToken).toHaveBeenCalledTimes(2);
-    });
-
-    it("ne refraichit le token qu'une seule fois si plusieurs requêtes échouent simultanément", async () => {
-      // Given
-      const accessToken = 'uytrdxcvghfrtyh';
-      const body = { some: 'body' };
-      const miss = nock('https://some.test.api')
-        .get('/test')
-        .twice()
-        .reply(401, 'Unauthorized');
-
-      const hit = nock('https://some.test.api', { reqheaders: { Authorization: `Bearer ${accessToken}` } })
-        .get('/test')
-        .twice()
-        .reply(200, body);
-
-      const deferred = new Deferred<string>();
-      const tokenAgentStub = {
-        getToken: jest.fn(() => deferred.promise),
-      };
-      const client = new HttpClientServiceWithAuthentification({
-        apiName: 'test',
-        apiUrl: 'https://some.test.api',
-        tokenAgent: tokenAgentStub,
-      });
-
-
-      // When
-      const req1 = client.get('/test', (a) => a);
-      const req2 = client.get('/test', (a) => a);
-      await becomeTrue(() => expect(miss.pendingMocks()).toHaveLength(0));
-
-      deferred.resolve(accessToken);
-      const [ res1, res2 ] = await Promise.all([req1, req2]);
-      // Then
-      miss.isDone();
-      hit.isDone();
-      expect(res1).toEqual(createSuccess(body));
-      expect(res2).toEqual(createSuccess(body));
-      expect(tokenAgentStub.getToken).toHaveBeenCalledTimes(1);
-    });
-
-    it('fait échouer toutes les requêtes en cours si le rafraichissement échoue', async () => {
-      // Given
-      const miss = nock('https://some.test.api')
-        .get('/test')
-        .twice()
-        .reply(401, 'Unauthorized');
-
-      const deferred = new Deferred<string>();
-      const tokenAgentStub = {
-        getToken: jest.fn(() => deferred.promise),
-      };
-      const client = new HttpClientServiceWithAuthentification({
-        apiName: 'test',
-        apiUrl: 'https://some.test.api',
-        tokenAgent: tokenAgentStub,
-      });
-
-
-      // When
-      const req1 = client.get('/test', (a) => a);
-      const req2 = client.get('/test', (a) => a);
-      await becomeTrue(() => expect(miss.pendingMocks()).toHaveLength(0));
-
-      deferred.reject(Error('Echec'));
-      const [ res1, res2 ] = await Promise.all([req1, req2]);
-      // Then
-      miss.isDone();
-      expect(res1).toEqual(createFailure(ErreurMétier.SERVICE_INDISPONIBLE));
-      expect(res2).toEqual(createFailure(ErreurMétier.SERVICE_INDISPONIBLE));
-    });
-  });
-  describe('.post(url)', () => {
-    afterEach(() => {
-      nock.cleanAll();
-    });
-    it('rafraichit un token quand il reçoit un 403', async () => {
-      // Given
-      const accessToken = 'uytrdxcvghfrtyh';
-      const body = { some: 'body' };
-      const miss = nock('https://some.test.api')
-        .post('/test')
-        .reply(403, 'forbidden');
-
-      const hit = nock('https://some.test.api', { reqheaders: { Authorization: `Bearer ${accessToken}` } })
-        .post('/test')
-        .reply(200, body);
-
-      const tokenAgentStub = {
-        getToken: jest.fn().mockResolvedValue(accessToken),
-      };
-      const client = new HttpClientServiceWithAuthentification({
-        apiName: 'test',
-        apiUrl: 'https://some.test.api',
-        tokenAgent: tokenAgentStub,
-      });
-
-
-      // When
-      const actual = await client.post('/test', {});
-      // Then
-      miss.isDone();
-      hit.isDone();
-      expect(actual.status).toEqual(200);
-    });
-    it('rafraichit un token quand il reçoit un 401', async () => {
-      // Given
-      const accessToken = 'uytrdxcvghfrtyh';
-      const body = { some: 'body' };
-      const miss = nock('https://some.test.api')
-        .post('/test')
-        .reply(401, 'Unauthorized');
-
-      const hit = nock('https://some.test.api', { reqheaders: { Authorization: `Bearer ${accessToken}` } })
-        .post('/test')
-        .reply(200, body);
-
-      const tokenAgentStub = {
-        getToken: jest.fn().mockResolvedValue(accessToken),
-      };
-      const client = new HttpClientServiceWithAuthentification({
-        apiName: 'test',
-        apiUrl: 'https://some.test.api',
-        tokenAgent: tokenAgentStub,
-      });
-
-
-      // When
-      const actual = await client.post('/test', {});
-      // Then
-      miss.isDone();
-      hit.isDone();
-      expect(actual.status).toEqual(200);
-    });
-    it('rafraichit un token qui a expiré', async () => {
-      // Given
-      const accessToken1 = 'uytrdxcvghfrtyh';
-      const accessToken2 = 'mpoijnbhjkloiuj';
-      const body = { some: 'body' };
-      const miss = nock('https://some.test.api')
-        .post('/test')
-        .reply(401, 'Unauthorized');
-
-      const hit = nock('https://some.test.api', { reqheaders: { Authorization: `Bearer ${accessToken1}` } })
-        .post('/test')
-        .reply(200, body);
-
-      const expires = nock('https://some.test.api', { reqheaders: { Authorization: `Bearer ${accessToken1}` } })
-        .post('/test')
-        .reply(401);
-
-      const hitRefreshed = nock('https://some.test.api', { reqheaders: { Authorization: `Bearer ${accessToken2}` } })
-        .post('/test')
-        .reply(200, body);
-
-      let refresh = false;
-      const tokenAgentStub = {
-        getToken: jest.fn(async () => {
-          if (!refresh) {
-            refresh = true;
-            return accessToken1;
-          } else {
-            return accessToken2;
-          }
-        }),
-      };
-      const client = new HttpClientServiceWithAuthentification({
-        apiName: 'test',
-        apiUrl: 'https://some.test.api',
-        tokenAgent: tokenAgentStub,
-      });
-
-
-      // When
-      const req1 = await client.post('/test', {});
-      const req2 = await client.post('/test', {});
-      // Then
-      miss.done();
-      hit.done();
-      expires.done();
-      hitRefreshed.done();
-      expect(req1.status).toEqual(200);
-      expect(req2.status).toEqual(200);
-      expect(tokenAgentStub.getToken).toHaveBeenCalledTimes(2);
-    });
-
-    it("ne refraichit le token qu'une seule fois si plusieurs requêtes échouent simultanément", async () => {
-      // Given
-      const accessToken = 'uytrdxcvghfrtyh';
-      const body = { some: 'body' };
-      const miss = nock('https://some.test.api')
-        .post('/test')
-        .twice()
-        .reply(401, 'Unauthorized');
-
-      const hit = nock('https://some.test.api', { reqheaders: { Authorization: `Bearer ${accessToken}` } })
-        .post('/test')
-        .twice()
-        .reply(200, body);
-
-      const deferred = new Deferred<string>();
-      const tokenAgentStub = {
-        getToken: jest.fn(() => deferred.promise),
-      };
-      const client = new HttpClientServiceWithAuthentification({
-        apiName: 'test',
-        apiUrl: 'https://some.test.api',
-        tokenAgent: tokenAgentStub,
-      });
-
-
-      // When
-      const req1 = client.post('/test', {});
-      const req2 = client.post('/test', {});
-      await becomeTrue(() => expect(miss.pendingMocks()).toHaveLength(0));
-
-      deferred.resolve(accessToken);
-      const [ res1, res2 ] = await Promise.all([req1, req2]);
-      // Then
-      miss.isDone();
-      hit.isDone();
-      expect(res1.status).toEqual(200);
-      expect(res2.status).toEqual(200);
-      expect(tokenAgentStub.getToken).toHaveBeenCalledTimes(1);
-    });
-
-    it('fait échouer toutes les requêtes en cours si le rafraichissement échoue', async () => {
-      // Given
-      const miss = nock('https://some.test.api')
-        .post('/test')
-        .twice()
-        .reply(401, 'Unauthorized');
-
-      const deferred = new Deferred<string>();
-      const tokenAgentStub = {
-        getToken: jest.fn(() => deferred.promise),
-      };
-      const client = new HttpClientServiceWithAuthentification({
-        apiName: 'test',
-        apiUrl: 'https://some.test.api',
-        tokenAgent: tokenAgentStub,
-      });
-
-
-      // When
-      const req1 = client.post('/test', {}).catch((e) => e);
-      const req2 = client.post('/test', {}).catch((e) => e);
-
-      await becomeTrue(() => expect(miss.pendingMocks()).toHaveLength(0));
-
-      deferred.reject(Error('Echec'));
-      const [ res1, res2 ] = await Promise.all([req1, req2]);
-      // Then
-      miss.isDone();
-      expect(res1.response.status).toEqual(401);
-      expect(res2.response.status).toEqual(401);
     });
   });
 });
-
-class Deferred<T> {
-  promise: Promise<T>;
-  done = false;
-  error = false;
-
-  reject!: (reason: Error) => void;
-  resolve!: (value: T) => void;
-
-  constructor () {
-    this.promise = new Promise((resolve, reject) => {
-      this.resolve = resolve;
-      this.reject = reject;
-    });
-  }
-}
-
-async function becomeTrue(predicate: () => void, timeout=200, interval=10) {
-  const end = Date.now() + timeout;
-  const [_, predicateString] = predicate.toString().split('\n').map((line: string) => line.replace(/^\s+(return ?)?/, ''));
-  let lastErrorMessage = '';
-  let tries = 0;
-  while (Date.now() < end) {
-    try {
-      tries++;
-      predicate();
-      await delay(interval);
-      return;
-    } catch (e) {
-      await delay(interval);
-      lastErrorMessage = (e as Error).message;
-    }
-  }
-  throw Error(`Condition '${chalk.italic(predicateString)}' did not become true after ${timeout}ms (${tries} tries)\n${lastErrorMessage}`);
-}
-
-function delay (ms: number) {
-  return new Promise((done) => setTimeout(done, ms));
-}
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,8 +24,8 @@
   },
   "include": [
     "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx",
     "types.d.ts",
   ],
   "exclude": [


### PR DESCRIPTION
J'ai géré le non logging de :
- les 204 sur le get
- les 204 sur la recherche
- les 400 avec les formats de message d'erreur qu'on connait (pour les gérer plus tard coté front)
Vous voyez d'autre cas à pas logger ?

Sinon tout le reste on log !