### PR TITLE
fix(decouvrir-les-metiers): correction bouton retour dans la page détail d'un metier

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ liste des contextes de **page** autorisées (non exaustive):
 - jobs étudiants
 - emplois europe
 - formations
-- dem (pour découvrir les métiers)
+- metiers (pour découvrir les métiers)
 - évènement
 - cej (pour contrat engagement jeune)
 - aides

--- a/src/pages/decouvrir-les-metiers/[id].tsx
+++ b/src/pages/decouvrir-les-metiers/[id].tsx
@@ -1,6 +1,7 @@
 import { GetStaticPathsResult, GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import { useRouter } from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { ButtonRetour } from '~/client/components/features/ButtonRetour/ButtonRetour';
 import { ConsulterFicheMétier } from '~/client/components/features/FicheMétier/Consulter/ConsulterFicheMétier';
@@ -20,6 +21,13 @@ interface ConsulterFicheMetierPageProps {
 }
 
 export default function ConsulterFicheMetierPage({ ficheMetier }: ConsulterFicheMetierPageProps) {
+  const router = useRouter();
+
+  useEffect(()=>{
+    window.addEventListener('popstate', () => router.reload() );
+    return () => window.removeEventListener('popstate', () => router.reload());
+  }, [router]);
+
   if (!ficheMetier) return null;
 
   return (


### PR DESCRIPTION
Note : même fix que pour https://github.com/DNUM-SocialGouv/1j1s-front/commit/372cdb30ae7efde3da7d47b59110e5e052186b6d