### PR TITLE
chore(google): ajout du fichier d'identification google

### DIFF
--- a/public/google7e90d409f9a92608.html
+++ b/public/google7e90d409f9a92608.html
@@ -1,0 +1,1 @@
+google-site-verification: google7e90d409f9a92608.html


### PR DESCRIPTION
le changement dns n'ayant pas été totalement effectué, la vérification pour le google webmastering tool a lieu via le fichier