### PR TITLE
fix: ajouter self parmi la liste des iframes autorisées par les CSP

### DIFF
--- a/config/headers.js
+++ b/config/headers.js
@@ -9,7 +9,7 @@ const contentSecurityPolicy = `
   img-src 'self' *.google.com data: ${STRAPI_MEDIA_HOST};
   style-src 'self' 'unsafe-inline';
   frame-ancestors 'none';
-  frame-src *.apprentissage.beta.gouv.fr immersion-facile.beta.gouv.fr deposer-offre.www.1jeune1solution.gouv.fr *.youtube.com;
+  frame-src 'self' *.apprentissage.beta.gouv.fr immersion-facile.beta.gouv.fr deposer-offre.www.1jeune1solution.gouv.fr *.youtube.com;
   form-action 'self';
   base-uri 'none';
 `;


### PR DESCRIPTION
Ceci vise à corriger le problème remonté par Pole Emploi pour la page "/emplois/deposer-offre":

> Bonjour,
> l’erreur étant :
> Refused to frame 'https://www.1jeune1solution.gouv.fr/maintenance-pole-emploi' because it violates the following Content Security Policy directive: "frame-src *.apprentissage.beta.gouv.fr immersion-facile.beta.gouv.fr deposer-offre.www.1jeune1solution.gouv.fr *.youtube.com".
> Et de ce que je vois des échanges réseau, la CSP en cause est celle-ci (dans laquelle il manquerait donc  www.1jeune1solution.gouv.fr) :
> content-security-policy:  […] frame-src *.apprentissage.beta.gouv.fr immersion-facile.beta.gouv.fr deposer-offre.www.1jeune1solution.gouv.fr *.youtube.com;
> Cette CSP est portée par la page https://www.1jeune1solution.gouv.fr/emplois/deposer-offre et est présente dans les headers de réponse. Ceci avant que l’iframe n’appelle la page Pole-Emploi.
> Du coup j’ai l’impression que le problème se situe avant d’arriver de notre côté.