### PR TITLE
fix(multiple): gestion erreur Sentry Api LBA et Trajectories Pro

### DIFF
--- a/src/pages/api/etablissements-accompagnement/index.controller.test.ts
+++ b/src/pages/api/etablissements-accompagnement/index.controller.test.ts
@@ -35,7 +35,7 @@ describe('rechercher un établissement d‘accompagnement', () => {
 		it('retourne une erreur Demande Incorrecte', async () => {
 			nock('https://etablissements-publics.api.gouv.fr/v3')
 				.get('/communes/46100/cij')
-				.reply(404, anAxiosError({ response: anAxiosResponse({}, 401) }));
+				.reply(404, anAxiosError({ response: anAxiosResponse({}, 404) }));
 
 			await testApiHandler<ÉtablissementAccompagnement[] | ErrorHttpResponse>({
 				handler: (req, res) => rechercherÉtablissementAccompagnementHandler(req, res),

--- a/src/server/alternances/infra/repositories/apiLaBonneAlternance.repository.test.ts
+++ b/src/server/alternances/infra/repositories/apiLaBonneAlternance.repository.test.ts
@@ -11,8 +11,8 @@ import {
 	Success,
 } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
+import { anHttpError } from '~/server/services/http/httpError.fixture';
 import {
-	anAxiosError,
 	anAxiosResponse,
 	aPublicHttpClientService,
 } from '~/server/services/http/publicHttpClient.service.fixture';
@@ -78,7 +78,7 @@ describe('ApiLaBonneAlternanceRepository', () => {
 		it('crée une erreur quand l’API renvoie une erreur', async () => {
 			// Given
 			const httpClientService = aPublicHttpClientService();
-			(httpClientService.get as jest.Mock).mockRejectedValue(anAxiosError({ status: 500 }));
+			(httpClientService.get as jest.Mock).mockRejectedValue(anHttpError(500));
 			const repository = new ApiLaBonneAlternanceRepository(httpClientService, '1jeune1solution-test');
 
 			// When

--- a/src/server/alternances/infra/repositories/apiLaBonneAlternance.repository.ts
+++ b/src/server/alternances/infra/repositories/apiLaBonneAlternance.repository.ts
@@ -7,7 +7,10 @@ import {
 	mapAlternanceListe,
 	mapMatcha, mapPEJob,
 } from '~/server/alternances/infra/repositories/apiLaBonneAlternance.mapper';
-import { handleSearchFailureError } from '~/server/alternances/infra/repositories/apiLaBonneAlternanceError';
+import {
+	handleGetFailureError,
+	handleSearchFailureError,
+} from '~/server/alternances/infra/repositories/apiLaBonneAlternanceError';
 import { createSuccess, Either } from '~/server/errors/either';
 import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
 
@@ -50,7 +53,7 @@ export class ApiLaBonneAlternanceRepository implements AlternanceRepository {
 			const matcha = apiResponse.data.matchas[0];
 			return createSuccess(mapMatcha(matcha));
 		} catch (error) {
-			return handleSearchFailureError(error, 'détail annonce alternance');
+			return handleGetFailureError(error, 'détail annonce alternance');
 		}
 	}
 }

--- a/src/server/alternances/infra/repositories/apiLaBonneAlternanceError.ts
+++ b/src/server/alternances/infra/repositories/apiLaBonneAlternanceError.ts
@@ -1,8 +1,8 @@
 import { createFailure } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { SentryException } from '~/server/exceptions/sentryException';
-import { LoggerService } from '~/server/services/logger.service';
 import { isHttpError } from '~/server/services/http/httpError';
+import { LoggerService } from '~/server/services/logger.service';
 
 export function handleSearchFailureError(e: unknown, context: string) {
 	return handleFailureError(e, `search ${context}`);

--- a/src/server/alternances/infra/repositories/apiLaBonneAlternanceError.ts
+++ b/src/server/alternances/infra/repositories/apiLaBonneAlternanceError.ts
@@ -1,13 +1,8 @@
-import axios, { AxiosError } from 'axios';
-
 import { createFailure } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { SentryException } from '~/server/exceptions/sentryException';
 import { LoggerService } from '~/server/services/logger.service';
-
-export interface ApiLaBonneAlternanceErrorResponse {
-	message: string
-}
+import { isHttpError } from '~/server/services/http/httpError';
 
 export function handleSearchFailureError(e: unknown, context: string) {
 	return handleFailureError(e, `search ${context}`);
@@ -22,13 +17,12 @@ export function handleGetMetierFailureError(e: unknown, context: string) {
 }
 
 export function handleFailureError(e: unknown, customContext: string) {
-	if (axios.isAxiosError(e)) {
-		const error = e as AxiosError<ApiLaBonneAlternanceErrorResponse>;
+	if (isHttpError(e)) {
 		LoggerService.errorWithExtra(
 			new SentryException(
 				'[API LaBonneAlternance] impossible d’effectuer une recherche',
 				{ context: customContext, source: 'API LaBonneAlternance' },
-				{ errorDetail: error.response?.data },
+				{ errorDetail: e.response?.data },
 			),
 		);
 		return createFailure(ErreurMétier.DEMANDE_INCORRECTE);

--- a/src/server/cms/infra/repositories/strapi.error.ts
+++ b/src/server/cms/infra/repositories/strapi.error.ts
@@ -1,21 +1,20 @@
-import axios, { AxiosResponse } from 'axios';
-
 import { createFailure } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { SentryException } from '~/server/exceptions/sentryException';
+import { isHttpError } from '~/server/services/http/httpError';
 import { LoggerService } from '~/server/services/logger.service';
 
 export function handleFailureError(e: unknown, context: string) {
-	if (axios.isAxiosError(e)) {
-		if (e.response?.status === 400 && (<AxiosResponse<{ message: string }>>e?.response)?.data?.message === '[API Strapi] 400 Bad request pour la ressource') {
+	if (isHttpError(e)) {
+		if (e.response?.status === 400 && e?.response?.data?.message === '[API Strapi] 400 Bad request pour la ressource') {
 			return createFailure(ErreurMétier.DEMANDE_INCORRECTE);
-		} else if (e.response?.status === 401 && (<AxiosResponse<{ message: string }>>e?.response)?.data?.message === '[API Strapi] 401 Unauthorized') {
+		} else if (e.response?.status === 401 && e?.response?.data?.message === '[API Strapi] 401 Unauthorized') {
 			return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
-		} else if (e.response?.status === 403 && (<AxiosResponse<{ message: string }>>e?.response)?.data?.message === '[API Strapi] 403 Forbidden pour la ressource') {
+		} else if (e.response?.status === 403 && e?.response?.data?.message === '[API Strapi] 403 Forbidden pour la ressource') {
 			return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
-		} else if (e.response?.status === 404 && (<AxiosResponse<{ message: string }>>e?.response)?.data?.message === '[API Strapi] 404 Contenu indisponible') {
+		} else if (e.response?.status === 404 && e?.response?.data?.message === '[API Strapi] 404 Contenu indisponible') {
 			return createFailure(ErreurMétier.CONTENU_INDISPONIBLE);
-		} else if (e.response?.status === 500 && (<AxiosResponse<{ message: string }>>e?.response)?.data?.message === '[API Strapi] 500 Internal server error') {
+		} else if (e.response?.status === 500 && e?.response?.data?.message === '[API Strapi] 500 Internal server error') {
 			return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
 		} else {
 			LoggerService.warnWithExtra(

--- a/src/server/cms/infra/repositories/strapi.repository.test.ts
+++ b/src/server/cms/infra/repositories/strapi.repository.test.ts
@@ -40,10 +40,10 @@ import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { FicheMétier } from '~/server/fiche-metier/domain/ficheMetier';
 import { aFicheMetier } from '~/server/fiche-metier/domain/ficheMetier.fixture';
 import { AuthenticatedHttpClientService } from '~/server/services/http/authenticatedHttpClient.service';
+import { anHttpError } from '~/server/services/http/httpError.fixture';
 import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
 import {
 	anAuthenticatedHttpClientService,
-	anAxiosError,
 	anAxiosResponse,
 	aPublicHttpClientService,
 } from '~/server/services/http/publicHttpClient.service.fixture';
@@ -125,7 +125,7 @@ describe('strapi cms repository', () => {
 		});
 		describe('Si aucune fiche métier n‘est trouvée', () => {
 			it('retourne une erreur', async () => {
-				jest.spyOn(httpClientService, 'get').mockRejectedValue(anAxiosError({ response: anAxiosResponse({}, 404) }));
+				jest.spyOn(httpClientService, 'get').mockRejectedValue(anHttpError(404, '', anAxiosResponse({}, 404)));
 
 				const result = await strapiCmsRepository.getFicheMetierByNom(nomMetier) as Failure;
 
@@ -242,7 +242,7 @@ describe('strapi cms repository', () => {
 				httpClientService = aPublicHttpClientService();
 				authenticatedHttpClientService = anAuthenticatedHttpClientService();
 				strapiCmsRepository = new StrapiRepository(httpClientService, authenticatedHttpClientService);
-				httpClientService.get = jest.fn().mockRejectedValue(anAxiosError({ response: anAxiosResponse({}, 404) }));
+				httpClientService.get = jest.fn().mockRejectedValue(anHttpError(404, '', anAxiosResponse({}, 404)));
 				const slug = 'bad-slug';
 
 				const result = await strapiCmsRepository.getAnnonceDeLogementBySlug(slug) as Failure;
@@ -310,7 +310,7 @@ describe('strapi cms repository', () => {
 				httpClientService = aPublicHttpClientService();
 				authenticatedHttpClientService = anAuthenticatedHttpClientService();
 				strapiCmsRepository = new StrapiRepository(httpClientService, authenticatedHttpClientService);
-				httpClientService.get = jest.fn().mockRejectedValue(anAxiosError({ response: anAxiosResponse({}, 404) }));
+				httpClientService.get = jest.fn().mockRejectedValue(anHttpError(404, '', anAxiosResponse({}, 404)));
 
 				const result = await strapiCmsRepository.getAllFAQ() as Failure;
 				expect(result.errorType).toEqual(ErreurMétier.CONTENU_INDISPONIBLE);
@@ -339,7 +339,7 @@ describe('strapi cms repository', () => {
 				httpClientService = aPublicHttpClientService();
 				authenticatedHttpClientService = anAuthenticatedHttpClientService();
 				strapiCmsRepository = new StrapiRepository(httpClientService, authenticatedHttpClientService);
-				httpClientService.get = jest.fn().mockRejectedValue(anAxiosError({ response: anAxiosResponse({}, 404) }));
+				httpClientService.get = jest.fn().mockRejectedValue(anHttpError(404, '', anAxiosResponse({}, 404)));
 
 				const result = await strapiCmsRepository.getFAQBySlug('not-found-slug') as Failure;
 				expect(result.errorType).toEqual(ErreurMétier.CONTENU_INDISPONIBLE);

--- a/src/server/cms/infra/repositories/strapi.repository.test.ts
+++ b/src/server/cms/infra/repositories/strapi.repository.test.ts
@@ -125,7 +125,7 @@ describe('strapi cms repository', () => {
 		});
 		describe('Si aucune fiche métier n‘est trouvée', () => {
 			it('retourne une erreur', async () => {
-				jest.spyOn(httpClientService, 'get').mockRejectedValue(anHttpError(404, '', anAxiosResponse({}, 404)));
+				jest.spyOn(httpClientService, 'get').mockRejectedValue(anHttpError(404));
 
 				const result = await strapiCmsRepository.getFicheMetierByNom(nomMetier) as Failure;
 
@@ -242,7 +242,7 @@ describe('strapi cms repository', () => {
 				httpClientService = aPublicHttpClientService();
 				authenticatedHttpClientService = anAuthenticatedHttpClientService();
 				strapiCmsRepository = new StrapiRepository(httpClientService, authenticatedHttpClientService);
-				httpClientService.get = jest.fn().mockRejectedValue(anHttpError(404, '', anAxiosResponse({}, 404)));
+				httpClientService.get = jest.fn().mockRejectedValue(anHttpError(404));
 				const slug = 'bad-slug';
 
 				const result = await strapiCmsRepository.getAnnonceDeLogementBySlug(slug) as Failure;
@@ -310,7 +310,7 @@ describe('strapi cms repository', () => {
 				httpClientService = aPublicHttpClientService();
 				authenticatedHttpClientService = anAuthenticatedHttpClientService();
 				strapiCmsRepository = new StrapiRepository(httpClientService, authenticatedHttpClientService);
-				httpClientService.get = jest.fn().mockRejectedValue(anHttpError(404, '', anAxiosResponse({}, 404)));
+				httpClientService.get = jest.fn().mockRejectedValue(anHttpError(404));
 
 				const result = await strapiCmsRepository.getAllFAQ() as Failure;
 				expect(result.errorType).toEqual(ErreurMétier.CONTENU_INDISPONIBLE);
@@ -339,7 +339,7 @@ describe('strapi cms repository', () => {
 				httpClientService = aPublicHttpClientService();
 				authenticatedHttpClientService = anAuthenticatedHttpClientService();
 				strapiCmsRepository = new StrapiRepository(httpClientService, authenticatedHttpClientService);
-				httpClientService.get = jest.fn().mockRejectedValue(anHttpError(404, '', anAxiosResponse({}, 404)));
+				httpClientService.get = jest.fn().mockRejectedValue(anHttpError(404));
 
 				const result = await strapiCmsRepository.getFAQBySlug('not-found-slug') as Failure;
 				expect(result.errorType).toEqual(ErreurMétier.CONTENU_INDISPONIBLE);

--- a/src/server/engagement/infra/repositories/apiEngagement.repository.test.ts
+++ b/src/server/engagement/infra/repositories/apiEngagement.repository.test.ts
@@ -12,7 +12,7 @@ import { Failure, Success } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { anHttpError } from '~/server/services/http/httpError.fixture';
 import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
-import { anAxiosError, anAxiosResponse, aPublicHttpClientService } from '~/server/services/http/publicHttpClient.service.fixture';
+import { anAxiosResponse, aPublicHttpClientService } from '~/server/services/http/publicHttpClient.service.fixture';
 
 jest.mock('axios', () => {
 	return {
@@ -60,7 +60,7 @@ describe('ApiEngagementRepository', () => {
 
 		describe('quand l’api engagement répond avec une erreur', () => {
 			it('retourne une erreur service indisponible', async () => {
-				jest.spyOn(httpClientService, 'get').mockRejectedValue(anAxiosError({}));
+				jest.spyOn(httpClientService, 'get').mockRejectedValue(anHttpError(500));
 				const rechercheServiceCivique: MissionEngagement.Recherche.ServiceCivique = {
 					domaine: 'sante',
 					localisation: {
@@ -109,7 +109,7 @@ describe('ApiEngagementRepository', () => {
 
 		describe('quand l’api engagement répond avec une erreur', () => {
 			it('retourne une erreur service indisponible', async () => {
-				jest.spyOn(httpClientService, 'get').mockRejectedValue(anAxiosError({}));
+				jest.spyOn(httpClientService, 'get').mockRejectedValue(anHttpError(500));
 				const rechercheBénévolat: MissionEngagement.Recherche.Benevolat = {
 					domaine: 'sante',
 					localisation: {
@@ -161,9 +161,7 @@ describe('ApiEngagementRepository', () => {
 
 		describe('quand l’api engagement répond avec un autre code d’erreur', () => {
 			it('retourne une erreur service indisponible', async () => {
-				jest.spyOn(httpClientService, 'get').mockRejectedValue(anAxiosError({
-					response: anAxiosResponse({}, 500),
-				}));
+				jest.spyOn(httpClientService, 'get').mockRejectedValue(anHttpError(500));
 
 				const result = await apiEngagementRepository.getMissionEngagement(missionEngagementId);
 

--- a/src/server/engagement/infra/repositories/apiEngagement.repository.test.ts
+++ b/src/server/engagement/infra/repositories/apiEngagement.repository.test.ts
@@ -6,11 +6,11 @@ import {
 import { ApiEngagementRepository } from '~/server/engagement/infra/repositories/apiEngagement.repository';
 import {
 	anAmbassadeurDuDonDeVêtementMissionResponse,
-	anInvalidIdMissionResponse,
 	aSearchMissionEngagementResponse,
 } from '~/server/engagement/infra/repositories/apiEngagement.response.fixture';
 import { Failure, Success } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
+import { anHttpError } from '~/server/services/http/httpError.fixture';
 import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
 import { anAxiosError, anAxiosResponse, aPublicHttpClientService } from '~/server/services/http/publicHttpClient.service.fixture';
 
@@ -143,7 +143,14 @@ describe('ApiEngagementRepository', () => {
 
 		describe('quand l’api engagement répond avec une 403', () => {
 			it('retourne une erreur contenu indisponible', async () => {
-				jest.spyOn(httpClientService, 'get').mockRejectedValue(anAxiosError(anInvalidIdMissionResponse()));
+				jest.spyOn(httpClientService, 'get').mockRejectedValue(anHttpError(403, '', anAxiosResponse(
+					{
+						data: null,
+						error: 'Id not valid',
+						ok: false,
+					},
+					403,
+				)));
 
 				const result = await apiEngagementRepository.getMissionEngagement(missionEngagementId);
 

--- a/src/server/engagement/infra/repositories/apiEngagementError.ts
+++ b/src/server/engagement/infra/repositories/apiEngagementError.ts
@@ -1,12 +1,11 @@
-import axios, { AxiosResponse } from 'axios';
-
 import { createFailure } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { SentryException } from '~/server/exceptions/sentryException';
+import { isHttpError } from '~/server/services/http/httpError';
 import { LoggerService } from '~/server/services/logger.service';
 
 export function handleSearchFailureError(e: unknown) {
-	if(axios.isAxiosError(e)) {
+	if(isHttpError(e)) {
 		LoggerService.errorWithExtra(new SentryException(
 			'[API Engagement] impossible d’effectuer une recherche',
 			{ context: 'recherche engagement', source: 'API Engagement' },
@@ -24,8 +23,8 @@ export function handleSearchFailureError(e: unknown) {
 }
 
 export function handleGetFailureError(e: unknown, context: string) {
-	if (axios.isAxiosError(e)) {
-		if(e.response?.status === 403 && (<AxiosResponse<{ error: string }>> e?.response)?.data?.error === 'Id not valid') {
+	if (isHttpError(e)) {
+		if(e.response?.status === 403 && e?.response?.data?.error === 'Id not valid') {
 			return createFailure(ErreurMétier.CONTENU_INDISPONIBLE);
 		} else {
 			LoggerService.warnWithExtra(

--- a/src/server/entreprises/infra/apiRejoindreLaMobilisationError.ts
+++ b/src/server/entreprises/infra/apiRejoindreLaMobilisationError.ts
@@ -1,17 +1,16 @@
-import axios, { AxiosResponse } from 'axios';
-
 import { createFailure } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { SentryException } from '~/server/exceptions/sentryException';
+import { isHttpError } from '~/server/services/http/httpError';
 import { LoggerService } from '~/server/services/logger.service';
 
 export function handleGetFailureError(e: unknown, context: string) {
-	if (axios.isAxiosError(e)) {
-		if(e.response?.status === 400 && (<AxiosResponse<{ message: string }>> e?.response)?.data?.message === '[API Rejoindre Mobilisation] 400 Bad request pour la ressource') {
+	if (isHttpError(e)) {
+		if(e.response?.status === 400 && e?.response?.data?.message === '[API Rejoindre Mobilisation] 400 Bad request pour la ressource') {
 			return createFailure(ErreurMétier.DEMANDE_INCORRECTE);
-		} else if(e.response?.status === 409 && (<AxiosResponse<{ message: string }>> e?.response)?.data?.message === '[API Rejoindre Mobilisation] 409 Conflict Identifiant') {
+		} else if(e.response?.status === 409 && e?.response?.data?.message === '[API Rejoindre Mobilisation] 409 Conflict Identifiant') {
 			return createFailure(ErreurMétier.CONFLIT_D_IDENTIFIANT);
-		} else if(e.response?.status === 404 && (<AxiosResponse<{ message: string }>> e?.response)?.data?.message === '[API Rejoindre Mobilisation] 404 Contenu indisponible') {
+		} else if(e.response?.status === 404 && e?.response?.data?.message === '[API Rejoindre Mobilisation] 404 Contenu indisponible') {
 			return createFailure(ErreurMétier.CONTENU_INDISPONIBLE);
 		} else {
 			LoggerService.errorWithExtra(

--- a/src/server/formations/infra/repositories/apiLaBonneAlternanceFormation.repository.test.ts
+++ b/src/server/formations/infra/repositories/apiLaBonneAlternanceFormation.repository.test.ts
@@ -10,6 +10,7 @@ import {
 import {
 	ApiLaBonneAlternanceFormationRepository,
 } from '~/server/formations/infra/repositories/apiLaBonneAlternanceFormation.repository';
+import { anHttpError } from '~/server/services/http/httpError.fixture';
 import { anAxiosError, anAxiosResponse, aPublicHttpClientService } from '~/server/services/http/publicHttpClient.service.fixture';
 
 describe('apiLaBonneAlternanceFormation.repository', () => {
@@ -115,12 +116,10 @@ describe('apiLaBonneAlternanceFormation.repository', () => {
 					it('retourne une erreur', async () => {
 						// Given
 						const httpClientService = aPublicHttpClientService();
-						(httpClientService.get as jest.Mock).mockRejectedValueOnce(anAxiosError({
-							response: anAxiosResponse({
-								error: 'internal_error',
-							}, 500),
-							status: 500,
-						}));
+						(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, '', anAxiosResponse({
+							error: 'internal_error',
+						}, 500),
+						));
 						(httpClientService.get as jest.Mock).mockResolvedValueOnce(anAxiosResponse(aLaBonneAlternanceApiRésultatRechercheFormationResponse()));
 
 						const repository = new ApiLaBonneAlternanceFormationRepository(httpClientService, '1jeune1solution-test');
@@ -138,12 +137,10 @@ describe('apiLaBonneAlternanceFormation.repository', () => {
 						it('retourne la formation trouvée sans lien de demande de rendez vous', async () => {
 							// Given
 							const httpClientService = aPublicHttpClientService();
-							(httpClientService.get as jest.Mock).mockRejectedValueOnce(anAxiosError({
-								response: anAxiosResponse({
-									error: 'internal_error',
-								}, 500),
-								status: 500,
-							}));
+							(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, '', anAxiosResponse({
+								error: 'internal_error',
+							}, 500),
+							));
 							(httpClientService.get as jest.Mock).mockResolvedValueOnce(anAxiosResponse(aLaBonneAlternanceApiRésultatRechercheFormationResponse()));
 
 							const id = '456__';
@@ -172,12 +169,10 @@ describe('apiLaBonneAlternanceFormation.repository', () => {
 						it('appelle l’api LaBonneAlternance avec les bons paramètres', async () => {
 							// Given
 							const httpClientService = aPublicHttpClientService();
-							(httpClientService.get as jest.Mock).mockRejectedValueOnce(anAxiosError({
-								response: anAxiosResponse({
-									error: 'internal_error',
-								}, 500),
-								status: 500,
-							}));
+							(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, '', anAxiosResponse({
+								error: 'internal_error',
+							}, 500),
+							));
 							(httpClientService.get as jest.Mock).mockResolvedValueOnce(anAxiosResponse(aLaBonneAlternanceApiRésultatRechercheFormationResponse()));
 
 							const repository = new ApiLaBonneAlternanceFormationRepository(httpClientService, '1jeune1solution-test');
@@ -197,12 +192,10 @@ describe('apiLaBonneAlternanceFormation.repository', () => {
 						it('retourne la formation trouvée avec le lien de demande de rendez vous', async () => {
 							// Given
 							const httpClientService = aPublicHttpClientService();
-							(httpClientService.get as jest.Mock).mockRejectedValueOnce(anAxiosError({
-								response: anAxiosResponse({
-									error: 'internal_error',
-								}, 500),
-								status: 500,
-							}));
+							(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, '', anAxiosResponse({
+								error: 'internal_error',
+							}, 500),
+							));
 							(httpClientService.get as jest.Mock).mockResolvedValueOnce(anAxiosResponse(aLaBonneAlternanceApiRésultatRechercheFormationResponse()));
 							(httpClientService.post as jest.Mock).mockResolvedValueOnce(anAxiosResponse({ form_url: 'url Demande de Rendez vous' }));
 

--- a/src/server/formations/infra/repositories/apiLaBonneAlternanceFormation.repository.test.ts
+++ b/src/server/formations/infra/repositories/apiLaBonneAlternanceFormation.repository.test.ts
@@ -11,7 +11,7 @@ import {
 	ApiLaBonneAlternanceFormationRepository,
 } from '~/server/formations/infra/repositories/apiLaBonneAlternanceFormation.repository';
 import { anHttpError } from '~/server/services/http/httpError.fixture';
-import { anAxiosError, anAxiosResponse, aPublicHttpClientService } from '~/server/services/http/publicHttpClient.service.fixture';
+import { anAxiosResponse, aPublicHttpClientService } from '~/server/services/http/publicHttpClient.service.fixture';
 
 describe('apiLaBonneAlternanceFormation.repository', () => {
 	describe('search', () => {
@@ -75,12 +75,7 @@ describe('apiLaBonneAlternanceFormation.repository', () => {
 			const id = 'formationId__';
 			const httpClientService = aPublicHttpClientService();
 			const repository = new ApiLaBonneAlternanceFormationRepository(httpClientService, '1jeune1solution-test');
-			(httpClientService.get as jest.Mock).mockRejectedValueOnce(anAxiosError({
-				response: anAxiosResponse({
-					error: 'internal_error',
-				}, 500),
-				status: 500,
-			}));
+			(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, 'internal_error'));
 
 			// When
 			repository.get(id);
@@ -95,12 +90,7 @@ describe('apiLaBonneAlternanceFormation.repository', () => {
 				it('retourne une erreur', async () => {
 					// Given
 					const httpClientService = aPublicHttpClientService();
-					(httpClientService.get as jest.Mock).mockRejectedValueOnce(anAxiosError({
-						response: anAxiosResponse({
-							error: 'internal_error',
-						}, 500),
-						status: 500,
-					}));
+					(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, 'internal_error'));
 					const repository = new ApiLaBonneAlternanceFormationRepository(httpClientService, '1jeune1solution-test');
 
 					// When
@@ -116,10 +106,7 @@ describe('apiLaBonneAlternanceFormation.repository', () => {
 					it('retourne une erreur', async () => {
 						// Given
 						const httpClientService = aPublicHttpClientService();
-						(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, '', anAxiosResponse({
-							error: 'internal_error',
-						}, 500),
-						));
+						(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, 'internal_error'));
 						(httpClientService.get as jest.Mock).mockResolvedValueOnce(anAxiosResponse(aLaBonneAlternanceApiRésultatRechercheFormationResponse()));
 
 						const repository = new ApiLaBonneAlternanceFormationRepository(httpClientService, '1jeune1solution-test');
@@ -137,10 +124,7 @@ describe('apiLaBonneAlternanceFormation.repository', () => {
 						it('retourne la formation trouvée sans lien de demande de rendez vous', async () => {
 							// Given
 							const httpClientService = aPublicHttpClientService();
-							(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, '', anAxiosResponse({
-								error: 'internal_error',
-							}, 500),
-							));
+							(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, 'internal_error'));
 							(httpClientService.get as jest.Mock).mockResolvedValueOnce(anAxiosResponse(aLaBonneAlternanceApiRésultatRechercheFormationResponse()));
 
 							const id = '456__';
@@ -169,10 +153,7 @@ describe('apiLaBonneAlternanceFormation.repository', () => {
 						it('appelle l’api LaBonneAlternance avec les bons paramètres', async () => {
 							// Given
 							const httpClientService = aPublicHttpClientService();
-							(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, '', anAxiosResponse({
-								error: 'internal_error',
-							}, 500),
-							));
+							(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, 'internal_error'));
 							(httpClientService.get as jest.Mock).mockResolvedValueOnce(anAxiosResponse(aLaBonneAlternanceApiRésultatRechercheFormationResponse()));
 
 							const repository = new ApiLaBonneAlternanceFormationRepository(httpClientService, '1jeune1solution-test');
@@ -192,10 +173,7 @@ describe('apiLaBonneAlternanceFormation.repository', () => {
 						it('retourne la formation trouvée avec le lien de demande de rendez vous', async () => {
 							// Given
 							const httpClientService = aPublicHttpClientService();
-							(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, '', anAxiosResponse({
-								error: 'internal_error',
-							}, 500),
-							));
+							(httpClientService.get as jest.Mock).mockRejectedValueOnce(anHttpError(500, 'internal_error'));
 							(httpClientService.get as jest.Mock).mockResolvedValueOnce(anAxiosResponse(aLaBonneAlternanceApiRésultatRechercheFormationResponse()));
 							(httpClientService.post as jest.Mock).mockResolvedValueOnce(anAxiosResponse({ form_url: 'url Demande de Rendez vous' }));
 

--- a/src/server/formations/infra/repositories/apiLaBonneAlternanceFormation.repository.ts
+++ b/src/server/formations/infra/repositories/apiLaBonneAlternanceFormation.repository.ts
@@ -15,8 +15,8 @@ import {
 	handleGetFailureError,
 	handleSearchFailureError,
 } from '~/server/formations/infra/repositories/apiLaBonneAlternanceFormationError';
-import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
 import { HttpError, isHttpError } from '~/server/services/http/httpError';
+import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
 
 const DEMANDE_RENDEZ_VOUS_REFERRER = 'jeune_1_solution';
 export const ID_FORMATION_SEPARATOR = '__';
@@ -100,7 +100,7 @@ export class ApiLaBonneAlternanceFormationRepository implements FormationReposit
 			if (!cleMinistereEducatif) {
 				return undefined;
 			}
-			const response = await this.httpClientService.post(
+			const response = await this.httpClientService.post<{ idCleMinistereEducatif: string, referrer: string }, { form_url: string }>(
 				'/appointment-request/context/create',
 				{
 					idCleMinistereEducatif: cleMinistereEducatif,

--- a/src/server/formations/infra/repositories/apiLaBonneAlternanceFormation.repository.ts
+++ b/src/server/formations/infra/repositories/apiLaBonneAlternanceFormation.repository.ts
@@ -1,7 +1,6 @@
 import { AxiosResponse, isAxiosError } from 'axios';
 
-import { handleSearchFailureError } from '~/server/alternances/infra/repositories/apiLaBonneAlternanceError';
-import { createFailure, createSuccess, Either, isSuccess } from '~/server/errors/either';
+import { createSuccess, Either, isSuccess } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { Formation, FormationFiltre, RésultatRechercheFormation } from '~/server/formations/domain/formation';
 import { FormationRepository } from '~/server/formations/domain/formation.repository';
@@ -14,6 +13,10 @@ import {
 	mapRésultatRechercheFormation,
 	mapRésultatRechercheFormationToFormation, parseIdFormation,
 } from '~/server/formations/infra/repositories/apiLaBonneAlternanceFormation.mapper';
+import {
+	handleGetFailureError,
+	handleSearchFailureError,
+} from '~/server/formations/infra/repositories/apiLaBonneAlternanceFormationError';
 import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
 
 const DEMANDE_RENDEZ_VOUS_REFERRER = 'jeune_1_solution';
@@ -70,10 +73,10 @@ export class ApiLaBonneAlternanceFormationRepository implements FormationReposit
 					formation.lienDemandeRendezVous = await this.getFormationLienRendezVous(cleMinistereEducatif);
 					return createSuccess(formation);
 				} catch (error) {
-					return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+					return handleGetFailureError(error, 'la bonne alternance get formation');
 				}
 			}
-			return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+			return handleGetFailureError(e, 'la bonne alternance get formation');
 		}
 	}
 

--- a/src/server/formations/infra/repositories/apiLaBonneAlternanceFormationError.ts
+++ b/src/server/formations/infra/repositories/apiLaBonneAlternanceFormationError.ts
@@ -1,7 +1,7 @@
 import { createFailure } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { SentryException } from '~/server/exceptions/sentryException';
-import { HttpError, isHttpError } from '~/server/services/http/httpError';
+import { isHttpError } from '~/server/services/http/httpError';
 import { LoggerService } from '~/server/services/logger.service';
 
 export function handleSearchFailureError(e: unknown, context: string) {
@@ -14,12 +14,11 @@ export function handleGetFailureError(e: unknown, context: string) {
 
 export function handleFailureError(e: unknown, customContext: string) {
 	if (isHttpError(e)) {
-		const error = e as HttpError;
 		LoggerService.errorWithExtra(
 			new SentryException(
 				'[API LaBonneAlternance] Formation : impossible d’effectuer une recherche',
 				{ context: customContext, source: 'API LaBonneAlternance Formation' },
-				{ errorDetail: error.response?.data },
+				{ errorDetail: e.response?.data },
 			),
 		);
 		return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);

--- a/src/server/formations/infra/repositories/apiLaBonneAlternanceFormationError.ts
+++ b/src/server/formations/infra/repositories/apiLaBonneAlternanceFormationError.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from 'axios';
+import { AxiosError } from 'axios';
 
 import { createFailure } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
@@ -18,22 +18,11 @@ export function handleGetFailureError(e: unknown, context: string) {
 }
 
 export function handleFailureError(e: unknown, customContext: string) {
-	if (axios.isAxiosError(e)) {
-		const error = e as AxiosError<ApiLaBonneAlternanceErrorResponse>;
-		LoggerService.errorWithExtra(
-			new SentryException(
-				'[API LaBonneAlternance] Formation : impossible d’effectuer une recherche',
-				{ context: customContext, source: 'API LaBonneAlternance Formation' },
-				{ errorDetail: error.response?.data },
-			),
-		);
-		return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
-	}
 	LoggerService.errorWithExtra(
 		new SentryException(
 			'[API LaBonneAlternance] Formation : impossible d’effectuer une recherche',
 			{ context: customContext, source: 'API LaBonneAlternance Formation' },
-			{ stacktrace: (<Error> e).stack },
+			{ errorDetail: (<AxiosError> e).response?.data || (<Error> e).stack },
 		),
 	);
 	return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);

--- a/src/server/formations/infra/repositories/apiLaBonneAlternanceFormationError.ts
+++ b/src/server/formations/infra/repositories/apiLaBonneAlternanceFormationError.ts
@@ -17,26 +17,22 @@ export function handleGetFailureError(e: unknown, context: string) {
 	return handleFailureError(e, `get ${context}`);
 }
 
-export function handleGetMetierFailureError(e: unknown, context: string) {
-	return handleFailureError(e, `get metier ${context}`);
-}
-
 export function handleFailureError(e: unknown, customContext: string) {
 	if (axios.isAxiosError(e)) {
 		const error = e as AxiosError<ApiLaBonneAlternanceErrorResponse>;
 		LoggerService.errorWithExtra(
 			new SentryException(
-				'[API LaBonneAlternance] impossible d’effectuer une recherche',
-				{ context: customContext, source: 'API LaBonneAlternance' },
+				'[API LaBonneAlternance] Formation : impossible d’effectuer une recherche',
+				{ context: customContext, source: 'API LaBonneAlternance Formation' },
 				{ errorDetail: error.response?.data },
 			),
 		);
-		return createFailure(ErreurMétier.DEMANDE_INCORRECTE);
+		return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
 	}
 	LoggerService.errorWithExtra(
 		new SentryException(
-			'[API LaBonneAlternance] impossible d’effectuer une recherche',
-			{ context: customContext, source: 'API LaBonneAlternance' },
+			'[API LaBonneAlternance] Formation : impossible d’effectuer une recherche',
+			{ context: customContext, source: 'API LaBonneAlternance Formation' },
 			{ stacktrace: (<Error> e).stack },
 		),
 	);

--- a/src/server/formations/infra/repositories/apiLaBonneAlternanceFormationError.ts
+++ b/src/server/formations/infra/repositories/apiLaBonneAlternanceFormationError.ts
@@ -1,13 +1,8 @@
-import { AxiosError } from 'axios';
-
 import { createFailure } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { SentryException } from '~/server/exceptions/sentryException';
+import { HttpError, isHttpError } from '~/server/services/http/httpError';
 import { LoggerService } from '~/server/services/logger.service';
-
-export interface ApiLaBonneAlternanceErrorResponse {
-	message: string
-}
 
 export function handleSearchFailureError(e: unknown, context: string) {
 	return handleFailureError(e, `search ${context}`);
@@ -18,12 +13,22 @@ export function handleGetFailureError(e: unknown, context: string) {
 }
 
 export function handleFailureError(e: unknown, customContext: string) {
+	if (isHttpError(e)) {
+		const error = e as HttpError;
+		LoggerService.errorWithExtra(
+			new SentryException(
+				'[API LaBonneAlternance] Formation : impossible d’effectuer une recherche',
+				{ context: customContext, source: 'API LaBonneAlternance Formation' },
+				{ errorDetail: error.response?.data },
+			),
+		);
+		return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+	}
 	LoggerService.errorWithExtra(
 		new SentryException(
 			'[API LaBonneAlternance] Formation : impossible d’effectuer une recherche',
 			{ context: customContext, source: 'API LaBonneAlternance Formation' },
-			{ errorDetail: (<AxiosError> e).response?.data || (<Error> e).stack },
+			{ stacktrace: (<Error> e).stack },
 		),
 	);
-	return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
-}
+	return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);}

--- a/src/server/formations/infra/repositories/apiTrajectoiresProStatistique.repository.test.ts
+++ b/src/server/formations/infra/repositories/apiTrajectoiresProStatistique.repository.test.ts
@@ -71,7 +71,7 @@ describe('apiTrajectoiresProCertification.repository', () => {
 					const returnValue = await repository.get(codeCertification, codePostal);
 
 					expect(httpService.get).toHaveBeenCalledTimes(1);
-					expect(returnValue).toEqual(createFailure(ErreurMétier.DEMANDE_INCORRECTE));
+					expect(returnValue).toEqual(createFailure(ErreurMétier.SERVICE_INDISPONIBLE));
 				});
 			});
 

--- a/src/server/formations/infra/repositories/apiTrajectoiresProStatistique.repository.test.ts
+++ b/src/server/formations/infra/repositories/apiTrajectoiresProStatistique.repository.test.ts
@@ -63,7 +63,7 @@ describe('apiTrajectoiresProCertification.repository', () => {
 			});
 
 			describe('lorsque l’appel à l’api trajectoiresProCertification échoue', () => {
-				it('retourne une erreur DEMANDE_INCORRECTE', async () => {
+				it('retourne une erreur SERVICE_INDISPONIBLE', async () => {
 					(apiGeoLocalisationHttpService.get as jest.Mock).mockResolvedValue({ data: [{ codeRegion: '11' }] });
 					(httpService.get as jest.Mock).mockRejectedValue(anAxiosError({ status: 500 }));
 					const repository = new ApiTrajectoiresProStatistiqueRepository(httpService, apiGeoLocalisationRepository);

--- a/src/server/formations/infra/repositories/apiTrajectoiresProStatistique.repository.test.ts
+++ b/src/server/formations/infra/repositories/apiTrajectoiresProStatistique.repository.test.ts
@@ -7,10 +7,10 @@ import { ApiTrajectoiresProStatistiqueResponse } from '~/server/formations/infra
 import { ApiTrajectoiresProStatistiqueRepository } from '~/server/formations/infra/repositories/apiTrajectoiresProStatistique.repository';
 import { ApiGeoRepository } from '~/server/localisations/infra/repositories/apiGeo.repository';
 import { CachedHttpClientService } from '~/server/services/http/cachedHttpClient.service';
+import { anHttpError } from '~/server/services/http/httpError.fixture';
 import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
 import {
 	aCachedHttpClientService,
-	anAxiosError,
 	aPublicHttpClientService,
 } from '~/server/services/http/publicHttpClient.service.fixture';
 
@@ -41,7 +41,7 @@ describe('apiTrajectoiresProCertification.repository', () => {
 
 		describe('lorsque l’appel à l’api geoLocalisation échoue', () => {
 			it('retourne une erreur SERVICE_INDISPONIBLE', async () => {
-				(apiGeoLocalisationHttpService.get as jest.Mock).mockRejectedValue(anAxiosError({ status: 500 }));
+				(apiGeoLocalisationHttpService.get as jest.Mock).mockRejectedValue(anHttpError(500));
 				const repository = new ApiTrajectoiresProStatistiqueRepository(httpService, apiGeoLocalisationRepository);
 
 				const returnValue = await repository.get(codeCertification, codePostal);
@@ -65,7 +65,7 @@ describe('apiTrajectoiresProCertification.repository', () => {
 			describe('lorsque l’appel à l’api trajectoiresProCertification échoue', () => {
 				it('retourne une erreur SERVICE_INDISPONIBLE', async () => {
 					(apiGeoLocalisationHttpService.get as jest.Mock).mockResolvedValue({ data: [{ codeRegion: '11' }] });
-					(httpService.get as jest.Mock).mockRejectedValue(anAxiosError({ status: 500 }));
+					(httpService.get as jest.Mock).mockRejectedValue(anHttpError(500));
 					const repository = new ApiTrajectoiresProStatistiqueRepository(httpService, apiGeoLocalisationRepository);
 
 					const returnValue = await repository.get(codeCertification, codePostal);

--- a/src/server/formations/infra/repositories/apiTrajectoiresProStatistique.repository.ts
+++ b/src/server/formations/infra/repositories/apiTrajectoiresProStatistique.repository.ts
@@ -1,4 +1,3 @@
-import { handleSearchFailureError } from '~/server/alternances/infra/repositories/apiLaBonneAlternanceError';
 import { createFailure, createSuccess, Either, isFailure } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { Statistique } from '~/server/formations/domain/statistique';
@@ -8,6 +7,7 @@ import {
 	isRegionEtAuMoinsUnPourcentageDisponible,
 } from '~/server/formations/infra/repositories/apiTrajectoiresProStatistique';
 import { mapStatistiques } from '~/server/formations/infra/repositories/apiTrajectoiresProStatistique.mapper';
+import { handleFailureError } from '~/server/formations/infra/repositories/apiTrajectoiresProStatistiqueError';
 import { ApiGeoRepository } from '~/server/localisations/infra/repositories/apiGeo.repository';
 import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
 
@@ -28,7 +28,7 @@ export class ApiTrajectoiresProStatistiqueRepository implements StatistiqueRepos
 			if (isRegionEtAuMoinsUnPourcentageDisponible(statistiques)) return createSuccess(statistiques);
 			return createFailure(ErreurMétier.CONTENU_INDISPONIBLE);
 		} catch (e) {
-			return handleSearchFailureError(e, 'statistique formation');
+			return handleFailureError(e, 'statistique formation');
 		}
 	}
 

--- a/src/server/formations/infra/repositories/apiTrajectoiresProStatistiqueError.ts
+++ b/src/server/formations/infra/repositories/apiTrajectoiresProStatistiqueError.ts
@@ -1,0 +1,32 @@
+import axios, { AxiosError } from 'axios';
+
+import { createFailure } from '~/server/errors/either';
+import { ErreurMétier } from '~/server/errors/erreurMétier.types';
+import { SentryException } from '~/server/exceptions/sentryException';
+import { LoggerService } from '~/server/services/logger.service';
+
+export interface ApiTrajectoiresProStatistiqueErrorResponse {
+	message: string
+}
+
+export function handleFailureError(e: unknown, customContext: string) {
+	if (axios.isAxiosError(e)) {
+		const error = e as AxiosError<ApiTrajectoiresProStatistiqueErrorResponse>;
+		LoggerService.errorWithExtra(
+			new SentryException(
+				'[API Trajectoires Pro] statistique de formation non disponible',
+				{ context: customContext, source: 'API Trajectoires Pro' },
+				{ errorDetail: error.response?.data },
+			),
+		);
+		return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+	}
+	LoggerService.errorWithExtra(
+		new SentryException(
+			'[API Trajectoires Pro] statistique de formation non disponible',
+			{ context: customContext, source: 'API Trajectoires Pro' },
+			{ stacktrace: (<Error> e).stack },
+		),
+	);
+	return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);
+}

--- a/src/server/formations/infra/repositories/apiTrajectoiresProStatistiqueError.ts
+++ b/src/server/formations/infra/repositories/apiTrajectoiresProStatistiqueError.ts
@@ -1,22 +1,16 @@
-import axios, { AxiosError } from 'axios';
-
 import { createFailure } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { SentryException } from '~/server/exceptions/sentryException';
+import { isHttpError } from '~/server/services/http/httpError';
 import { LoggerService } from '~/server/services/logger.service';
 
-export interface ApiTrajectoiresProStatistiqueErrorResponse {
-	message: string
-}
-
 export function handleFailureError(e: unknown, customContext: string) {
-	if (axios.isAxiosError(e)) {
-		const error = e as AxiosError<ApiTrajectoiresProStatistiqueErrorResponse>;
+	if (isHttpError(e)) {
 		LoggerService.errorWithExtra(
 			new SentryException(
 				'[API Trajectoires Pro] statistique de formation non disponible',
 				{ context: customContext, source: 'API Trajectoires Pro' },
-				{ errorDetail: error.response?.data },
+				{ errorDetail: e.response?.data },
 			),
 		);
 		return createFailure(ErreurMétier.SERVICE_INDISPONIBLE);

--- a/src/server/localisations/infra/repositories/apiAdresse.repository.test.ts
+++ b/src/server/localisations/infra/repositories/apiAdresse.repository.test.ts
@@ -9,7 +9,6 @@ import { anHttpError } from '~/server/services/http/httpError.fixture';
 import {
 	aCacheAxiosResponse,
 	aCachedHttpClientService,
-	anAxiosResponse,
 } from '~/server/services/http/publicHttpClient.service.fixture';
 
 describe('ApiAdresseRepository', () => {
@@ -125,10 +124,7 @@ describe('ApiAdresseRepository', () => {
 			it('renvoie une demande incorrecte', async () => {
 				jest
 					.spyOn(httpClientService, 'get')
-					.mockRejectedValue(anHttpError(400, '', anAxiosResponse(
-						{ message: 'q must contain at least 3 chars and start with a number or a letter' },
-						400),
-					));
+					.mockRejectedValue(anHttpError(400, 'q must contain at least 3 chars and start with a number or a letter'));
 				const recherche = 'jou';
 
 				const result = await apiAdresseRepository.getCommuneList(recherche) as Failure;

--- a/src/server/localisations/infra/repositories/apiAdresse.repository.test.ts
+++ b/src/server/localisations/infra/repositories/apiAdresse.repository.test.ts
@@ -5,10 +5,10 @@ import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { RésultatsRechercheCommune } from '~/server/localisations/domain/localisationAvecCoordonnées';
 import { ApiAdresseRepository } from '~/server/localisations/infra/repositories/apiAdresse.repository';
 import { CachedHttpClientService } from '~/server/services/http/cachedHttpClient.service';
+import { anHttpError } from '~/server/services/http/httpError.fixture';
 import {
 	aCacheAxiosResponse,
 	aCachedHttpClientService,
-	anAxiosError,
 	anAxiosResponse,
 } from '~/server/services/http/publicHttpClient.service.fixture';
 
@@ -125,11 +125,10 @@ describe('ApiAdresseRepository', () => {
 			it('renvoie une demande incorrecte', async () => {
 				jest
 					.spyOn(httpClientService, 'get')
-					.mockRejectedValue(anAxiosError({
-						response: anAxiosResponse(
-							{ message: 'q must contain at least 3 chars and start with a number or a letter' },
-							400),
-					}));
+					.mockRejectedValue(anHttpError(400, '', anAxiosResponse(
+						{ message: 'q must contain at least 3 chars and start with a number or a letter' },
+						400),
+					));
 				const recherche = 'jou';
 
 				const result = await apiAdresseRepository.getCommuneList(recherche) as Failure;

--- a/src/server/localisations/infra/repositories/apiGeo.error.ts
+++ b/src/server/localisations/infra/repositories/apiGeo.error.ts
@@ -1,23 +1,19 @@
-import axios, { AxiosError, AxiosResponse } from 'axios';
-
 import { createFailure } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { SentryException } from '~/server/exceptions/sentryException';
+import { isHttpError } from '~/server/services/http/httpError';
 import { LoggerService } from '~/server/services/logger.service';
 
-import { ApiDecoupageAdministratifResponse } from './apiGeo.response';
-
 export function handleGetFailureError(e: unknown, context: string) {
-	if (axios.isAxiosError(e)) {
-		const error: AxiosError<ApiDecoupageAdministratifResponse> = e as AxiosError<ApiDecoupageAdministratifResponse>;
-		if(error.response?.status === 400 && (<AxiosResponse<{ message: string }>> e?.response)?.data?.message === 'Le format de l\'id de la localisation recherchée est incorrect.') {
+	if (isHttpError(e)) {
+		if(e.response?.status === 400 && e.response.data?.message === 'Le format de l\'id de la localisation recherchée est incorrect.') {
 			return createFailure(ErreurMétier.DEMANDE_INCORRECTE);
 		} else {
 			LoggerService.warnWithExtra(
 				new SentryException(
 					'[API Localisation] impossible de récupérer une ressource',
 					{ context: `détail ${context}`, source: 'API Localisation' },
-					{ errorDetail: error.response?.data },
+					{ errorDetail: e.response?.data },
 				),
 			);
 			return createFailure(ErreurMétier.DEMANDE_INCORRECTE);

--- a/src/server/mail/infra/repositories/tipimail.repository.test.ts
+++ b/src/server/mail/infra/repositories/tipimail.repository.test.ts
@@ -7,7 +7,8 @@ import { aTipimailRequest, aTipimailRequestWithRedirection } from '~/server/mail
 import {
 	TipimailRepository,
 } from '~/server/mail/infra/repositories/tipimail.repository';
-import { anAxiosError, anAxiosResponse, aPublicHttpClientService } from '~/server/services/http/publicHttpClient.service.fixture';
+import { anHttpError } from '~/server/services/http/httpError.fixture';
+import { anAxiosResponse, aPublicHttpClientService } from '~/server/services/http/publicHttpClient.service.fixture';
 
 jest.mock('@sentry/nextjs');
 
@@ -45,9 +46,7 @@ describe('TipimailRepository', () => {
 				it('renvoie une erreur demande incorrecte', async () => {
 					// given
 					const httpClient = aPublicHttpClientService();
-					jest.spyOn(httpClient, 'post').mockRejectedValue(anAxiosError({
-						response: anAxiosResponse({}, 400),
-					}));
+					jest.spyOn(httpClient, 'post').mockRejectedValue(anHttpError(400));
 
 					const repository = new TipimailRepository(httpClient, true);
 					const tipimailRequest = aTipimailRequest();
@@ -67,9 +66,7 @@ describe('TipimailRepository', () => {
 				it('renvoie une erreur service indisponible', async () => {
 					// given
 					const httpClient = aPublicHttpClientService();
-					jest.spyOn(httpClient, 'post').mockRejectedValue(anAxiosError({
-						response: anAxiosResponse({}, 401),
-					}));
+					jest.spyOn(httpClient, 'post').mockRejectedValue(anHttpError(401));
 
 					const repository = new TipimailRepository(httpClient, true);
 					const tipimailRequest = aTipimailRequest();
@@ -89,9 +86,7 @@ describe('TipimailRepository', () => {
 				it('renvoie une erreur service indisponible', async () => {
 					// given
 					const httpClient = aPublicHttpClientService();
-					jest.spyOn(httpClient, 'post').mockRejectedValue(anAxiosError({
-						response: anAxiosResponse({}, 500),
-					}));
+					jest.spyOn(httpClient, 'post').mockRejectedValue(anHttpError(500));
 					const repository = new TipimailRepository(httpClient, true);
 					const tipimailRequest = aTipimailRequest();
 					const mail = aMail();

--- a/src/server/mail/infra/repositories/tipimail.repository.ts
+++ b/src/server/mail/infra/repositories/tipimail.repository.ts
@@ -1,11 +1,10 @@
-import axios from 'axios';
-
 import { createFailure, createSuccess, Either } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { SentryException } from '~/server/exceptions/sentryException';
 import { Mail } from '~/server/mail/domain/mail';
 import { MailRepository } from '~/server/mail/domain/mail.repository';
 import { mapTipimailRequest } from '~/server/mail/infra/repositories/tipimail.mapper';
+import { isHttpError } from '~/server/services/http/httpError';
 import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
 import { LoggerService } from '~/server/services/logger.service';
 
@@ -36,7 +35,7 @@ export class TipimailRepository implements MailRepository {
 					{ errorDetail: e },
 				),
 			);
-			if (axios.isAxiosError(e)) {
+			if (isHttpError(e)) {
 				if (e.response?.status === 400) {
 					return createFailure(ErreurMétier.DEMANDE_INCORRECTE);
 				}

--- a/src/server/metiers/infra/apiLaBonneAlternanceMétier.repository.test.ts
+++ b/src/server/metiers/infra/apiLaBonneAlternanceMétier.repository.test.ts
@@ -8,7 +8,8 @@ import {
 import {
 	ApiLaBonneAlternanceMétierRepository,
 } from '~/server/metiers/infra/apiLaBonneAlternanceMétier.repository';
-import { anAxiosError, anAxiosResponse, aPublicHttpClientService } from '~/server/services/http/publicHttpClient.service.fixture';
+import { anHttpError } from '~/server/services/http/httpError.fixture';
+import { anAxiosResponse, aPublicHttpClientService } from '~/server/services/http/publicHttpClient.service.fixture';
 
 describe('ApiLaBonneAlternanceMétierRepository', () => {
 	describe('getMetierList', () => {
@@ -30,7 +31,7 @@ describe('ApiLaBonneAlternanceMétierRepository', () => {
 		describe('Quand l‘api renvoie une erreur', () => {
 			it("retourne une instance d'erreur", async () => {
 				const httpClientService = aPublicHttpClientService();
-				(httpClientService.get as jest.Mock).mockRejectedValue(anAxiosError({ status: 429 }));
+				(httpClientService.get as jest.Mock).mockRejectedValue(anHttpError(429));
 				const repository = new ApiLaBonneAlternanceMétierRepository(httpClientService);
 
 				const response = await repository.getMetierList('tran');

--- a/src/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError.test.ts
+++ b/src/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError.test.ts
@@ -5,18 +5,12 @@ import {
 	handleSearchFailureError,
 } from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError';
 import { anHttpError } from '~/server/services/http/httpError.fixture';
-import { anAxiosResponse } from '~/server/services/http/publicHttpClient.service.fixture';
 
 describe('handleSearchFailureError', () => {
 	errorFromApiPoleEmploi.forEach((messageErrorFromApiPoleEmploi) => {
 		describe(`quand l’api renvoie une erreur 400 et le message d’erreur ${messageErrorFromApiPoleEmploi}`, () => {
 			it('retourne une failure demande incorrecte sans logger', async () => {
-				const error = anHttpError(400, messageErrorFromApiPoleEmploi, anAxiosResponse(
-					{
-						message: messageErrorFromApiPoleEmploi,
-					},
-					400,
-				));
+				const error = anHttpError(400, messageErrorFromApiPoleEmploi);
 
 				const result = await handleSearchFailureError(error, 'context') as Failure;
 
@@ -27,12 +21,7 @@ describe('handleSearchFailureError', () => {
 
 	describe('quand l’api renvoie une erreur 400 et un message inconnue', () => {
 		it('retourne une failure demande incorrecte en loggant', async () => {
-			const error = anHttpError(400, 'message inconnu', anAxiosResponse(
-				{
-					message: 'message inconnu',
-				},
-				400,
-			));
+			const error = anHttpError(400, 'message inconnu');
 
 			const result = await handleSearchFailureError(error, 'context') as Failure;
 

--- a/src/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError.test.ts
+++ b/src/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError.test.ts
@@ -4,20 +4,19 @@ import {
 	errorFromApiPoleEmploi,
 	handleSearchFailureError,
 } from '~/server/offres/infra/repositories/pole-emploi/apiPoleEmploiError';
-import { anAxiosError, anAxiosResponse } from '~/server/services/http/publicHttpClient.service.fixture';
+import { anHttpError } from '~/server/services/http/httpError.fixture';
+import { anAxiosResponse } from '~/server/services/http/publicHttpClient.service.fixture';
 
 describe('handleSearchFailureError', () => {
 	errorFromApiPoleEmploi.forEach((messageErrorFromApiPoleEmploi) => {
 		describe(`quand l’api renvoie une erreur 400 et le message d’erreur ${messageErrorFromApiPoleEmploi}`, () => {
 			it('retourne une failure demande incorrecte sans logger', async () => {
-				const error = anAxiosError({
-					response: anAxiosResponse(
-						{
-							message: messageErrorFromApiPoleEmploi,
-						},
-						400,
-					),
-				});
+				const error = anHttpError(400, messageErrorFromApiPoleEmploi, anAxiosResponse(
+					{
+						message: messageErrorFromApiPoleEmploi,
+					},
+					400,
+				));
 
 				const result = await handleSearchFailureError(error, 'context') as Failure;
 
@@ -28,14 +27,12 @@ describe('handleSearchFailureError', () => {
 
 	describe('quand l’api renvoie une erreur 400 et un message inconnue', () => {
 		it('retourne une failure demande incorrecte en loggant', async () => {
-			const error = anAxiosError({
-				response: anAxiosResponse(
-					{
-						message: 'message inconnu',
-					},
-					400,
-				),
-			});
+			const error = anHttpError(400, 'message inconnu', anAxiosResponse(
+				{
+					message: 'message inconnu',
+				},
+				400,
+			));
 
 			const result = await handleSearchFailureError(error, 'context') as Failure;
 

--- a/src/server/services/http/cachedHttpClient.service.ts
+++ b/src/server/services/http/cachedHttpClient.service.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import { AxiosCacheInstance, CacheAxiosResponse, setupCache } from 'axios-cache-interceptor';
 
+import { HttpError } from '~/server/services/http/httpError';
 import { PublicHttpClientConfig } from '~/server/services/http/publicHttpClient.service';
 
 export class CachedHttpClientService {
@@ -16,10 +17,24 @@ export class CachedHttpClientService {
 		endpoint: string,
 		config?: AxiosRequestConfig,
 	): Promise<CacheAxiosResponse<Response>> {
-		return this.client.get<Response>(endpoint, config);
+		try {
+			return this.client.get<Response>(endpoint, config);
+		} catch (e) {
+			if (axios.isAxiosError(e) && e.response) {
+				throw new HttpError(e.response.status, e.response.data.message, e.response);
+			}
+			throw e;
+		}
 	}
 
 	async post<Body>(endpoint: string, body: Body) {
-		return this.client.post(endpoint, body);
+		try {
+			return this.client.post(endpoint, body);
+		} catch (e) {
+			if (axios.isAxiosError(e) && e.response) {
+				throw new HttpError(e.response.status, e.response.data.message, e.response);
+			}
+			throw e;
+		}
 	}
 }

--- a/src/server/services/http/httpError.fixture.ts
+++ b/src/server/services/http/httpError.fixture.ts
@@ -1,0 +1,7 @@
+import { AxiosResponse } from 'axios';
+
+import { HttpError } from '~/server/services/http/httpError';
+
+export function anHttpError(status?: number, message?: string, response?: AxiosResponse): HttpError {
+	return new HttpError(status || 500, message || 'An error occurred', response);
+}

--- a/src/server/services/http/httpError.fixture.ts
+++ b/src/server/services/http/httpError.fixture.ts
@@ -1,7 +1,12 @@
 import { AxiosResponse } from 'axios';
 
 import { HttpError } from '~/server/services/http/httpError';
+import { anAxiosResponse } from '~/server/services/http/publicHttpClient.service.fixture';
 
 export function anHttpError(status?: number, message?: string, response?: AxiosResponse): HttpError {
-	return new HttpError(status || 500, message || 'An error occurred', response);
+	return new HttpError(status || 500, message || 'An error occurred', response || anAxiosResponse({
+		error: message || 'An error occurred',
+		message: message || 'An error occurred',
+		status: status || 500,
+	}, status || 500));
 }

--- a/src/server/services/http/httpError.ts
+++ b/src/server/services/http/httpError.ts
@@ -1,0 +1,14 @@
+export class HttpError extends Error {
+	public response?: {
+		data: unknown;
+	};
+
+	constructor (public status: number, message: string, response?: { data: unknown }) {
+		super(message);
+		this.response = response;
+	}
+}
+
+export function isHttpError(e: unknown): e is HttpError {
+	return e instanceof HttpError;
+}

--- a/src/server/services/http/httpError.ts
+++ b/src/server/services/http/httpError.ts
@@ -1,9 +1,9 @@
-export class HttpError extends Error {
-	public response?: {
-		data: unknown;
-	};
+import { AxiosResponse } from 'axios';
 
-	constructor (public status: number, message: string, response?: { data: unknown }) {
+export class HttpError extends Error {
+	public response?: AxiosResponse;
+
+	constructor (public status: number, message: string, response?: AxiosResponse) {
 		super(message);
 		this.response = response;
 	}

--- a/src/server/services/http/publicHttpClient.service.ts
+++ b/src/server/services/http/publicHttpClient.service.ts
@@ -1,5 +1,7 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 
+import { HttpError } from '~/server/services/http/httpError';
+
 export interface PublicHttpClientConfig {
 	apiName: string
 	apiUrl: string
@@ -19,10 +21,28 @@ export class PublicHttpClientService {
 		endpoint: string,
 		config?: AxiosRequestConfig,
 	): Promise<AxiosResponse<Response>> {
-		return this.client.get<Response>(endpoint, config);
+		try {
+			return this.client.get<Response>(endpoint, config);
+		} catch (e) {
+			if (axios.isAxiosError(e) && e.response) {
+				throw new HttpError(e.response.status, e.response.data.message, e.response);
+			}
+			throw e;
+		}
 	}
 
 	async post<Body, Response>(endpoint: string, body: Body): Promise<AxiosResponse<Response>> {
-		return this.client.post<Response>(endpoint, body);
+		try {
+			return this.client.post<Response>(endpoint, body);
+		} catch (e) {
+			if (axios.isAxiosError(e) && e.response) {
+				throw new HttpError(e.response.status, e.response.data.message, e.response);
+			}
+			throw e;
+		}
+	}
+
+	protected setAuthorizationHeader(token: string): void {
+		this.client.defaults.headers.common.Authorization = `Bearer ${token}`;
 	}
 }

--- a/src/server/services/http/publicHttpClient.service.ts
+++ b/src/server/services/http/publicHttpClient.service.ts
@@ -22,7 +22,7 @@ export class PublicHttpClientService {
 		config?: AxiosRequestConfig,
 	): Promise<AxiosResponse<Response>> {
 		try {
-			return this.client.get<Response>(endpoint, config);
+			return await this.client.get<Response>(endpoint, config);
 		} catch (e) {
 			if (axios.isAxiosError(e) && e.response) {
 				throw new HttpError(e.response.status, e.response.data.message, e.response);
@@ -33,7 +33,7 @@ export class PublicHttpClientService {
 
 	async post<Body, Response>(endpoint: string, body: Body): Promise<AxiosResponse<Response>> {
 		try {
-			return this.client.post<Response>(endpoint, body);
+			return await this.client.post<Response>(endpoint, body);
 		} catch (e) {
 			if (axios.isAxiosError(e) && e.response) {
 				throw new HttpError(e.response.status, e.response.data.message, e.response);

--- a/src/server/établissement-accompagnement/infra/apiÉtablissementPublic.repository.test.ts
+++ b/src/server/établissement-accompagnement/infra/apiÉtablissementPublic.repository.test.ts
@@ -5,7 +5,6 @@ import { aRésultatRechercheÉtablissementPublicResponse } from '~/server/établ
 import { ApiÉtablissementPublicRepository } from '~/server/établissement-accompagnement/infra/apiÉtablissementPublic.repository';
 import { anHttpError } from '~/server/services/http/httpError.fixture';
 import {
-	anAxiosError,
 	anAxiosResponse,
 	aPublicHttpClientService,
 } from '~/server/services/http/publicHttpClient.service.fixture';
@@ -58,9 +57,7 @@ describe('ApiÉtablissementPublicRepository', () => {
 			it('renvoie une erreur service indisponible', async () => {
 				// given
 				const httpClient = aPublicHttpClientService();
-				jest.spyOn(httpClient, 'get').mockRejectedValue(anAxiosError({
-					response: anAxiosResponse({}, 500),
-				}));
+				jest.spyOn(httpClient, 'get').mockRejectedValue(anHttpError(500));
 				const commune = '46100';
 				const typeAccompagnement = 'cij';
 

--- a/src/server/établissement-accompagnement/infra/apiÉtablissementPublic.repository.test.ts
+++ b/src/server/établissement-accompagnement/infra/apiÉtablissementPublic.repository.test.ts
@@ -3,6 +3,7 @@ import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import { anOrderedÉtablissementAccompagnementList } from '~/server/établissement-accompagnement/domain/etablissementAccompagnement.fixture';
 import { aRésultatRechercheÉtablissementPublicResponse } from '~/server/établissement-accompagnement/infra/apiÉtablissementPublic.fixture';
 import { ApiÉtablissementPublicRepository } from '~/server/établissement-accompagnement/infra/apiÉtablissementPublic.repository';
+import { anHttpError } from '~/server/services/http/httpError.fixture';
 import {
 	anAxiosError,
 	anAxiosResponse,
@@ -36,9 +37,9 @@ describe('ApiÉtablissementPublicRepository', () => {
 			it('renvoie une erreur demande incorrecte', async () => {
 				// given
 				const httpClient = aPublicHttpClientService();
-				jest.spyOn(httpClient, 'get').mockRejectedValue(anAxiosError({
-					response: anAxiosResponse({}, 404),
-				}));
+				jest.spyOn(httpClient, 'get').mockRejectedValue(anHttpError(404, '',
+					anAxiosResponse({}, 404),
+				));
 				const commune = '46100';
 				const typeAccompagnement = 'cij';
 

--- a/src/server/établissement-accompagnement/infra/apiÉtablissementPublic.repository.ts
+++ b/src/server/établissement-accompagnement/infra/apiÉtablissementPublic.repository.ts
@@ -1,5 +1,3 @@
-import axios from 'axios';
-
 import { createFailure, createSuccess, Either } from '~/server/errors/either';
 import { ErreurMétier } from '~/server/errors/erreurMétier.types';
 import {
@@ -16,6 +14,7 @@ import {
 	RésultatRechercheÉtablissementPublicResponse,
 } from '~/server/établissement-accompagnement/infra/apiÉtablissementPublic.response';
 import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
+import { isHttpError } from '~/server/services/http/httpError';
 import { LoggerService } from '~/server/services/logger.service';
 
 export class ApiÉtablissementPublicRepository implements ÉtablissementAccompagnementRepository {
@@ -29,7 +28,7 @@ export class ApiÉtablissementPublicRepository implements ÉtablissementAccompag
 			return createSuccess(mapÉtablissementAccompagnement(data));
 		} catch (e) {
 			LoggerService.error('[API Établissement Public] Erreur lors de la recherche d‘Établissement Public');
-			if (axios.isAxiosError(e)) {
+			if (isHttpError(e)) {
 				if (e.response?.status === 404) {
 					return createFailure(ErreurMétier.DEMANDE_INCORRECTE);
 				}

--- a/src/server/établissement-accompagnement/infra/apiÉtablissementPublic.repository.ts
+++ b/src/server/établissement-accompagnement/infra/apiÉtablissementPublic.repository.ts
@@ -13,8 +13,8 @@ import {
 import {
 	RésultatRechercheÉtablissementPublicResponse,
 } from '~/server/établissement-accompagnement/infra/apiÉtablissementPublic.response';
-import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
 import { isHttpError } from '~/server/services/http/httpError';
+import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
 import { LoggerService } from '~/server/services/logger.service';
 
 export class ApiÉtablissementPublicRepository implements ÉtablissementAccompagnementRepository {


### PR DESCRIPTION
Correction sur ce que je disais au daily : des erreurs sont aussi déclenché lorsque la page est affiché en mode dégradé (ex : les statistiques ne sont pas trouvé)
👉 Est ce qu'il faudrait passer en log de niveau warn pour créer moins de bruit sur Sentry ?