### PR TITLE
ci: active le cache des node_modules pour accélerer les Github Actions

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - name: Install Lighthouse CI
         run: npm install -g @lhci/cli@0.12.x
       - name: Run Lighthouse CI

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -25,5 +25,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm ci && cp .env.test .env
       - run: npm run build

--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm ci && cp .env.test .env
       - name: Start redis
         run: |

--- a/.github/workflows/run-lint-and-unit-test.yml
+++ b/.github/workflows/run-lint-and-unit-test.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm ci
       - run: npm run lint
       - run: tsc --noEmit


### PR DESCRIPTION
Cette PR active le cache pour `npm` (c'est à dire le dossier `node_modules`) afin d'accélérer les Github Actions.
Cela doit permettre également de faire moins de requêtes vers le registry npm et d'autres sources de packages et de binaires et d'éviter les erreurs de quota comme celle-ci: https://github.com/DNUM-SocialGouv/1j1s-front/actions/runs/5066896242/jobs/9097261698?pr=1354