### PR TITLE
chore(terraform): upgrade de redis en recette vers redis-starter-256

### DIFF
--- a/terraform/front.tf
+++ b/terraform/front.tf
@@ -28,8 +28,9 @@ module "front_app" {
 
   addons = [
     {
-      provider = "redis"
-      plan     = terraform.workspace == "production" ? "redis-business-256" : "redis-starter-256"
+      provider          = "redis"
+      plan              = terraform.workspace == "production" ? "redis-business-256" : "redis-starter-256"
+      database_features = ["redis-rdb"]
     }
   ]
 

--- a/terraform/front.tf
+++ b/terraform/front.tf
@@ -29,7 +29,7 @@ module "front_app" {
   addons = [
     {
       provider = "redis"
-      plan     = terraform.workspace == "production" ? "redis-business-256" : "redis-sandbox"
+      plan     = terraform.workspace == "production" ? "redis-business-256" : "redis-starter-256"
     }
   ]
 


### PR DESCRIPTION
pour des raisons contractuelles entre les ministères et Scalingo. Il nous est désormais interdit d'utiliser des addons qui n'ont pas de SLA, y compris pour les environnement hors-prod.

Résoud une tâche JIRA pas encore créée ^^