### PR TITLE
feat(stage): mettre a jour le wording sur la page de detail dun stage

### DIFF
--- a/src/client/components/features/OffreDeStage/Consulter/ConsulterOffreDeStage.test.tsx
+++ b/src/client/components/features/OffreDeStage/Consulter/ConsulterOffreDeStage.test.tsx
@@ -3,7 +3,6 @@
  */
 
 import { render, screen, within } from '@testing-library/react';
-import * as domain from 'domain';
 
 import { ConsulterOffreDeStage } from '~/client/components/features/OffreDeStage/Consulter/ConsulterOffreDeStage';
 import { mockUseRouter } from '~/client/components/useRouter.mock';
@@ -61,7 +60,7 @@ describe('ConsulterOffreDeStage', () => {
 		});
 
 		describe('dans les étiquettes', () => {
-			it('pour les domaines du stage', () => {
+			it('concernant les domaines du stage', () => {
 				const offreDeStage = uneOffreDeStage({ domaines: [Domaines.ACHAT, Domaines.CONSEIL] });
 
 				render(<ConsulterOffreDeStage offreDeStage={offreDeStage}/>);
@@ -71,7 +70,7 @@ describe('ConsulterOffreDeStage', () => {
 				expect(displayedTagsTextContents).toContain(Domaines.ACHAT);
 				expect(displayedTagsTextContents).toContain(Domaines.CONSEIL);
 			});
-			describe('pour la localisation du stage', () => {
+			describe('concernant la localisation du stage', () => {
 				it('affiche la ville du stage quand elle est présente', () => {
 					const localisation = anOffreDeStageLocalisation({ ville: 'Paris' });
 					const offreDeStage = uneOffreDeStage({ localisation: localisation });
@@ -105,13 +104,36 @@ describe('ConsulterOffreDeStage', () => {
 					expect(displayedTagsTextContents).toContain(localisation.region);
 				});
 			});
-			describe('pour la durée du stage', () => {
-			  it('affiche une durée catégorisée quand elle est supérieure à 0', () => {
+			describe('concernant la durée du stage', () => {
+				it('affiche une durée catégorisée quand elle est supérieure à 0', () => {
+					const offreDeStage = uneOffreDeStage({ dureeEnJour: 60 });
 
-			  });
+					render(<ConsulterOffreDeStage offreDeStage={offreDeStage}/>);
+
+					const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre de stage' });
+					const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+					expect(displayedTagsTextContents).toContain('2 mois');
+				});
 			});
 			describe('concernant la date de début du stage', () => {
+				it('affiche la date de début précise quand il y a une date précise', () => {
+					const offreDeStage = uneOffreDeStage({ dateDeDebutMax: '2024-09-01', dateDeDebutMin: '2024-09-01' });
 
+					render(<ConsulterOffreDeStage offreDeStage={offreDeStage}/>);
+
+					const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre de stage' });
+					const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+					expect(displayedTagsTextContents).toContain('Débute le : 9/1/2024');
+				});
+				it('affiche la période de date de début quand la date de début est une période de date', () => {
+					const offreDeStage = uneOffreDeStage({ dateDeDebutMax: '2024-09-30', dateDeDebutMin: '2024-09-01' });
+
+					render(<ConsulterOffreDeStage offreDeStage={offreDeStage}/>);
+
+					const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre de stage' });
+					const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+					expect(displayedTagsTextContents).toContain('Débute entre le : 9/1/2024 et 9/30/2024');
+				});
 			});
 		});
 	});

--- a/src/client/components/features/OffreDeStage/Consulter/ConsulterOffreDeStage.test.tsx
+++ b/src/client/components/features/OffreDeStage/Consulter/ConsulterOffreDeStage.test.tsx
@@ -66,7 +66,7 @@ describe('ConsulterOffreDeStage', () => {
 				render(<ConsulterOffreDeStage offreDeStage={offreDeStage}/>);
 
 				const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre de stage' });
-				const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+				const displayedTagsTextContents = within(displayedTagsList).getAllByRole('listitem').map((listItem) => listItem.textContent);
 				expect(displayedTagsTextContents).toContain(Domaines.ACHAT);
 				expect(displayedTagsTextContents).toContain(Domaines.CONSEIL);
 			});
@@ -78,7 +78,7 @@ describe('ConsulterOffreDeStage', () => {
 					render(<ConsulterOffreDeStage offreDeStage={offreDeStage}/>);
 
 					const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre de stage' });
-					const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+					const displayedTagsTextContents = within(displayedTagsList).getAllByRole('listitem').map((listItem) => listItem.textContent);
 					expect(displayedTagsTextContents).toContain(localisation.ville);
 				});
 
@@ -89,7 +89,7 @@ describe('ConsulterOffreDeStage', () => {
 					render(<ConsulterOffreDeStage offreDeStage={offreDeStage}/>);
 
 					const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre de stage' });
-					const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+					const displayedTagsTextContents = within(displayedTagsList).getAllByRole('listitem').map((listItem) => listItem.textContent);
 					expect(displayedTagsTextContents).toContain(localisation.departement);
 				});
 
@@ -100,7 +100,7 @@ describe('ConsulterOffreDeStage', () => {
 					render(<ConsulterOffreDeStage offreDeStage={offreDeStage}/>);
 
 					const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre de stage' });
-					const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+					const displayedTagsTextContents = within(displayedTagsList).getAllByRole('listitem').map((listItem) => listItem.textContent);
 					expect(displayedTagsTextContents).toContain(localisation.region);
 				});
 			});
@@ -111,7 +111,7 @@ describe('ConsulterOffreDeStage', () => {
 					render(<ConsulterOffreDeStage offreDeStage={offreDeStage}/>);
 
 					const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre de stage' });
-					const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+					const displayedTagsTextContents = within(displayedTagsList).getAllByRole('listitem').map((listItem) => listItem.textContent);
 					expect(displayedTagsTextContents).toContain('2 mois');
 				});
 			});
@@ -122,7 +122,7 @@ describe('ConsulterOffreDeStage', () => {
 					render(<ConsulterOffreDeStage offreDeStage={offreDeStage}/>);
 
 					const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre de stage' });
-					const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+					const displayedTagsTextContents = within(displayedTagsList).getAllByRole('listitem').map((listItem) => listItem.textContent);
 					expect(displayedTagsTextContents).toContain('Débute le : 9/1/2024');
 				});
 				it('affiche la période de date de début quand la date de début est une période de date', () => {
@@ -131,7 +131,7 @@ describe('ConsulterOffreDeStage', () => {
 					render(<ConsulterOffreDeStage offreDeStage={offreDeStage}/>);
 
 					const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre de stage' });
-					const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+					const displayedTagsTextContents = within(displayedTagsList).getAllByRole('listitem').map((listItem) => listItem.textContent);
 					expect(displayedTagsTextContents).toContain('Débute entre le : 9/1/2024 et 9/30/2024');
 				});
 			});

--- a/src/client/components/features/OffreDeStage/Consulter/ConsulterOffreDeStage.tsx
+++ b/src/client/components/features/OffreDeStage/Consulter/ConsulterOffreDeStage.tsx
@@ -16,7 +16,10 @@ export function ConsulterOffreDeStage({ offreDeStage }: ConsulterOffreDeStagePro
 	const listeEtiquettes = useMemo(() => {
 		return [...offreDeStage.domaines, offreDeStage.localisation?.ville || offreDeStage.localisation?.departement || offreDeStage.localisation?.region,
 			dureeCategorisee(offreDeStage.dureeEnJour || 0),
-			'Débute le : ' + new Date(offreDeStage.dateDeDebut).toLocaleDateString()];
+			offreDeStage.dateDeDebutMin === offreDeStage.dateDeDebutMax
+				? `Débute le : ${new Date(offreDeStage.dateDeDebutMin).toLocaleDateString()}`
+				: `Débute entre le : ${new Date(offreDeStage.dateDeDebutMin).toLocaleDateString()} et ${new Date(offreDeStage.dateDeDebutMax).toLocaleDateString()}`,
+		];
 	}, [offreDeStage]);
 
 	const salaireOffreDeStage = offreDeStage.remunerationBase?.toString();

--- a/src/client/components/features/OffreDeStage/OffreDeStage.test.tsx
+++ b/src/client/components/features/OffreDeStage/OffreDeStage.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, within } from '@testing-library/react';
+
+import { OffreDeStage } from '~/client/components/features/OffreDeStage/OffreDeStage';
+import {
+	aLocalisationStageIndexee,
+	anOffreDeStageIndexee,
+} from '~/client/components/features/OffreDeStage/offreDeStageIndexee.fixture';
+import { mockUseRouter } from '~/client/components/useRouter.mock';
+import { mockSmallScreen } from '~/client/components/window.mock';
+import { Domaines } from '~/server/cms/domain/offreDeStage.type';
+
+describe('Une carte d’offre de stage affiche des étiquettes', () => {
+
+	beforeEach(() => {
+		mockSmallScreen();
+		mockUseRouter({});
+	});
+
+	function someDummy() {
+		return;
+	}
+
+	describe('concernant les domaines du stage', () => {
+		it('un domaine "Non renseigné" n’est pas affiché', () => {
+			const displayedDomain = Domaines.MAINTENANCE;
+			const displayedFormattedDomain = 'Qualité / Maintenance';
+			const offreStage = anOffreDeStageIndexee({ domaines: [displayedDomain, Domaines.NON_RENSEIGNE] });
+
+			render(
+				<OffreDeStage
+					hit={offreStage}
+					sendEvent={someDummy}
+				/>,
+			);
+
+			const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre' });
+			const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+			expect(displayedTagsTextContents).toContain(displayedFormattedDomain);
+			expect(displayedTagsTextContents).not.toContain('Non Renseigné');
+		});
+	});
+
+	describe('concernant la localisation du stage', () => {
+		it('si la ville est connue, affiche la ville', () => {
+			const localisationWithCity = aLocalisationStageIndexee({ ville: 'Paris' });
+
+			const offreStage = anOffreDeStageIndexee({ localisation: localisationWithCity });
+
+			render(
+				<OffreDeStage
+					hit={offreStage}
+					sendEvent={someDummy}
+				/>,
+			);
+
+			const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre' });
+			const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+			expect(displayedTagsTextContents).toContain(localisationWithCity.ville);
+		});
+		it('si la ville n’est pas connue, mais le département est connue, affiche le département', () => {
+			const localisationWithDepartment = aLocalisationStageIndexee({ departement: 'Val de marne', ville: undefined });
+
+			const offreStage = anOffreDeStageIndexee({ localisation: localisationWithDepartment });
+
+			render(
+				<OffreDeStage
+					hit={offreStage}
+					sendEvent={someDummy}
+				/>,
+			);
+
+			const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre' });
+			const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+			expect(displayedTagsTextContents).toContain(localisationWithDepartment.departement);
+		});
+		it('si ni la ville, ni le département ne sont connus, mais que la région est connue, affiche la région', () => {
+			const localisationWithRegion = aLocalisationStageIndexee({ departement: undefined, region: 'Ile de France', ville: undefined });
+
+			const offreStage = anOffreDeStageIndexee({ localisation: localisationWithRegion });
+
+			render(
+				<OffreDeStage
+					hit={offreStage}
+					sendEvent={someDummy}
+				/>,
+			);
+
+			const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre' });
+			const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+			expect(displayedTagsTextContents).toContain(localisationWithRegion.region);
+		});
+
+		// comment je peux tester le cas où quand pas de localisation, aucun tag ?
+	});
+
+	describe('concernant la durée du stage', () => {
+		it('une durée catégorisée "Non renseignée" n’est pas affichée', () => {
+			const offreStage = anOffreDeStageIndexee({ dureeCategorisee: 'Non renseigné' });
+
+			render(
+				<OffreDeStage
+					hit={offreStage}
+					sendEvent={someDummy}
+				/>,
+			);
+
+			const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre' });
+			const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+			expect(displayedTagsTextContents).not.toContain('Non renseigné');
+		});
+	});
+
+	describe('concernant la date de début du stage', () => {
+		describe('quand la date de début est une date précise', () => {
+			it('la date précise est affichée', () => {
+				const datePrecise = '2024-09-01';
+				const offreStage = anOffreDeStageIndexee({ dateDeDebutMax: datePrecise, dateDeDebutMin: datePrecise });
+
+				render(
+					<OffreDeStage
+						hit={offreStage}
+						sendEvent={someDummy}
+					/>,
+				);
+
+				const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre' });
+				const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+				expect(displayedTagsTextContents).toContain('Débute le : 9/1/2024');
+			});
+		});
+
+		describe('quand la date de début est une période de date', () => {
+			it('la période de date de début est affichée', () => {
+				const datePeriodeDebut = '2024-09-01';
+				const datePeriodeFin = '2024-09-30';
+				const offreStage = anOffreDeStageIndexee({ dateDeDebutMax: datePeriodeFin, dateDeDebutMin: datePeriodeDebut });
+
+				render(
+					<OffreDeStage
+						hit={offreStage}
+						sendEvent={someDummy}
+					/>,
+				);
+
+				const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre' });
+				const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+				expect(displayedTagsTextContents).toContain('Débute entre le : 9/1/2024 et 9/30/2024');
+			});
+		});
+	});
+
+	describe('quand il n’y a aucune information concernant les domaines, la localisation, la durée categorisée', () => {
+		it('n’affiche aucune étiquettes les concernant, seule la date de début est affichée', () => {
+			const offreStage = anOffreDeStageIndexee({
+				domaines: [],
+				dureeCategorisee: undefined,
+				localisation: aLocalisationStageIndexee({
+					departement: undefined,
+					region: undefined,
+					ville: undefined,
+				}),
+			});
+
+			render(
+				<OffreDeStage
+					hit={offreStage}
+					sendEvent={someDummy}
+				/>,
+			);
+
+			const displayedTagsList = screen.getByRole('list', { name: 'Caractéristiques de l‘offre' });
+			const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
+			expect(displayedTagsTextContents).toHaveLength(1);
+			expect(displayedTagsTextContents[0]).toBe('Débute le : 9/1/2024');
+		});
+	});
+});

--- a/src/client/components/features/OffreDeStage/OffreDeStage.test.tsx
+++ b/src/client/components/features/OffreDeStage/OffreDeStage.test.tsx
@@ -93,8 +93,6 @@ describe('Une carte d’offre de stage affiche des étiquettes', () => {
 			const displayedTagsTextContents = within(displayedTagsList).queryAllByRole('listitem').map((listItem) => listItem.textContent);
 			expect(displayedTagsTextContents).toContain(localisationWithRegion.region);
 		});
-
-		// comment je peux tester le cas où quand pas de localisation, aucun tag ?
 	});
 
 	describe('concernant la durée du stage', () => {

--- a/src/client/components/features/OffreDeStage/OffreDeStage.tsx
+++ b/src/client/components/features/OffreDeStage/OffreDeStage.tsx
@@ -12,17 +12,17 @@ const IMAGE_FIXE = '/images/logos/fallback.svg';
 
 export function OffreDeStage (props : HitProps<OffreDeStageIndexée>) {
 	const stage = props.hit;
-	// TODO (BRUJ 14-06-2023): à supprimer après la mise en place du nouveau modèle de données
-	const dateDeDebut = stage.dateDeDebut || stage.dateDeDebutMin;
 	const listeEtiquettes: Array<string> = stage.domaines
 		? stage.domaines
 			.filter((domaine) => domaine !== Domaines.NON_RENSEIGNE)
 			.map((domaine) => getCapitalizedItems(domaine))
 		: [];
 	listeEtiquettes.push(
-		stage.localisation?.ville || stage.localisation?.departement || stage.localisation?.region as string,
-		stage.dureeCategorisee !== 'Non renseigné' ? stage.dureeCategorisee as string : '',
-		'Débute le : ' + new Date(dateDeDebut).toLocaleDateString(),
+		stage.localisation?.ville || stage.localisation?.departement || stage.localisation?.region,
+		stage.dureeCategorisee !== 'Non renseigné' ? stage.dureeCategorisee.toString() : '',
+		stage.dateDeDebutMin === stage.dateDeDebutMax
+			? `Débute le : ${new Date(stage.dateDeDebutMin).toLocaleDateString()}`
+			: `Débute entre le : ${new Date(stage.dateDeDebutMin).toLocaleDateString()} et ${new Date(stage.dateDeDebutMax).toLocaleDateString()}`,
 	);
 
 	return <RésultatRechercherSolution

--- a/src/client/components/features/OffreDeStage/OffreDeStage.tsx
+++ b/src/client/components/features/OffreDeStage/OffreDeStage.tsx
@@ -17,8 +17,13 @@ export function OffreDeStage (props : HitProps<OffreDeStageIndexée>) {
 			.filter((domaine) => domaine !== Domaines.NON_RENSEIGNE)
 			.map((domaine) => getCapitalizedItems(domaine))
 		: [];
+
+	const etiquetteLocalisation = stage.localisation?.ville || stage.localisation?.departement || stage.localisation?.region
+	if (etiquetteLocalisation) {
+		listeEtiquettes.push(etiquetteLocalisation)
+	}
+
 	listeEtiquettes.push(
-		stage.localisation?.ville || stage.localisation?.departement || stage.localisation?.region || '',
 		stage.dureeCategorisee && stage.dureeCategorisee !== 'Non renseigné' ? stage.dureeCategorisee : '',
 		stage.dateDeDebutMin === stage.dateDeDebutMax
 			? `Débute le : ${new Date(stage.dateDeDebutMin).toLocaleDateString()}`

--- a/src/client/components/features/OffreDeStage/OffreDeStage.tsx
+++ b/src/client/components/features/OffreDeStage/OffreDeStage.tsx
@@ -18,8 +18,8 @@ export function OffreDeStage (props : HitProps<OffreDeStageIndexée>) {
 			.map((domaine) => getCapitalizedItems(domaine))
 		: [];
 	listeEtiquettes.push(
-		stage.localisation?.ville || stage.localisation?.departement || stage.localisation?.region,
-		stage.dureeCategorisee !== 'Non renseigné' ? stage.dureeCategorisee.toString() : '',
+		stage.localisation?.ville || stage.localisation?.departement || stage.localisation?.region || '',
+		stage.dureeCategorisee && stage.dureeCategorisee !== 'Non renseigné' ? stage.dureeCategorisee : '',
 		stage.dateDeDebutMin === stage.dateDeDebutMax
 			? `Débute le : ${new Date(stage.dateDeDebutMin).toLocaleDateString()}`
 			: `Débute entre le : ${new Date(stage.dateDeDebutMin).toLocaleDateString()} et ${new Date(stage.dateDeDebutMax).toLocaleDateString()}`,

--- a/src/client/components/features/OffreDeStage/OffreDeStage.tsx
+++ b/src/client/components/features/OffreDeStage/OffreDeStage.tsx
@@ -18,9 +18,9 @@ export function OffreDeStage (props : HitProps<OffreDeStageIndexée>) {
 			.map((domaine) => getCapitalizedItems(domaine))
 		: [];
 
-	const etiquetteLocalisation = stage.localisation?.ville || stage.localisation?.departement || stage.localisation?.region
+	const etiquetteLocalisation = stage.localisation?.ville || stage.localisation?.departement || stage.localisation?.region;
 	if (etiquetteLocalisation) {
-		listeEtiquettes.push(etiquetteLocalisation)
+		listeEtiquettes.push(etiquetteLocalisation);
 	}
 
 	listeEtiquettes.push(

--- a/src/client/components/features/OffreDeStage/offreDeStageIndexee.fixture.ts
+++ b/src/client/components/features/OffreDeStage/offreDeStageIndexee.fixture.ts
@@ -1,0 +1,37 @@
+import { LocalisationStageIndexée, OffreDeStageIndexée, SourceDesDonnées } from '../../../../server/cms/domain/offreDeStage.type';
+
+export function anOffreDeStageIndexee(override?: Partial<OffreDeStageIndexée>): OffreDeStageIndexée {
+	return {
+		dateDeDebutMax: '2024-09-01',
+		dateDeDebutMin: '2024-09-01',
+		description: 'Poste ouvert aux personnes en situation de handicap',
+		domaines: [],
+		duree: undefined,
+		dureeCategorisee: '2 mois',
+		dureeEnJour: 720,
+		dureeEnJourMax: 800,
+		id: 'offre-stage-id',
+		localisation: {
+			pays: 'France',
+		},
+		logoUrlEmployeur: 'www.vienstravailler.example.com',
+		nomEmployeur: 'Viens travailler',
+		remunerationBase: 1000,
+		slug: 'stage-audit-tours-h-f-036780b7-95ba-4711-bf26-471d1f95051c',
+		source: SourceDesDonnées.JOBTEASER,
+		teletravailPossible: true,
+		titre: 'un stage d’audit',
+		...override,
+	};
+}
+
+export function aLocalisationStageIndexee(override?: Partial<LocalisationStageIndexée>): LocalisationStageIndexée {
+	return {
+		codePostal: undefined,
+		departement: undefined,
+		pays: 'France',
+		region: undefined,
+		ville: 'Paris',
+		...override,
+	};
+}

--- a/src/client/components/features/OffreDeStage/offreDeStageIndexee.fixture.ts
+++ b/src/client/components/features/OffreDeStage/offreDeStageIndexee.fixture.ts
@@ -1,4 +1,4 @@
-import { LocalisationStageIndexée, OffreDeStageIndexée, SourceDesDonnées } from '../../../../server/cms/domain/offreDeStage.type';
+import { LocalisationStageIndexée, OffreDeStageIndexée, SourceDesDonnées } from '~/server/cms/domain/offreDeStage.type';
 
 export function anOffreDeStageIndexee(override?: Partial<OffreDeStageIndexée>): OffreDeStageIndexée {
 	return {

--- a/src/server/cms/domain/offreDeStage.fixture.ts
+++ b/src/server/cms/domain/offreDeStage.fixture.ts
@@ -2,7 +2,8 @@ import { OffreDeStage, SourceDesDonnées } from '~/server/cms/domain/offreDeStag
 
 export function uneOffreDeStage(): OffreDeStage {
 	return {
-		dateDeDebut: '2024-09-01',
+		dateDeDebutMax: '2024-09-01',
+		dateDeDebutMin: '2024-09-01',
 		description: 'Poste ouvert aux personnes en situation de handicap',
 		domaines: [],
 		dureeEnJour: 720,

--- a/src/server/cms/domain/offreDeStage.fixture.ts
+++ b/src/server/cms/domain/offreDeStage.fixture.ts
@@ -1,6 +1,7 @@
 import { OffreDeStage, SourceDesDonnées } from '~/server/cms/domain/offreDeStage.type';
+import Localisation = OffreDeStage.Localisation;
 
-export function uneOffreDeStage(): OffreDeStage {
+export function uneOffreDeStage(overrides?: Partial<OffreDeStage>): OffreDeStage {
 	return {
 		dateDeDebutMax: '2024-09-01',
 		dateDeDebutMin: '2024-09-01',
@@ -28,5 +29,17 @@ export function uneOffreDeStage(): OffreDeStage {
 		teletravailPossible: true,
 		titre: 'Alternance Audit - Tours ( H/F)',
 		urlDeCandidature: 'https://www.jobteaser.com/en/job-offers/10067252',
+		...overrides,
+	};
+}
+
+export function anOffreDeStageLocalisation(override?: Partial<Localisation>): Localisation {
+	return {
+		codePostal: undefined,
+		departement: undefined,
+		pays: undefined,
+		region: undefined,
+		ville: undefined,
+		...override,
 	};
 }

--- a/src/server/cms/domain/offreDeStage.type.ts
+++ b/src/server/cms/domain/offreDeStage.type.ts
@@ -116,7 +116,8 @@ export interface OffreDeStage {
 	titre: string
 	id: string
 	slug: string
-	dateDeDebut: string
+	dateDeDebutMin: string
+	dateDeDebutMax: string
 	description: string
 	urlDeCandidature?: string
 	domaines: Array<Domaines>

--- a/src/server/cms/domain/offreDeStage.type.ts
+++ b/src/server/cms/domain/offreDeStage.type.ts
@@ -67,11 +67,9 @@ export enum SourceDesDonnées {
 	STAGEFR_DECOMPRESSE = 'stagefr-decompresse',
 }
 
-// TODO (BRUJ 14-06-2023): à changer après la mise en place du nouveau modèle de données
 export type OffreDeStageIndexée = {
 	titre: string
 	description: string
-	dateDeDebut: string
 	dateDeDebutMin: string
 	dateDeDebutMax: string
 	id: string

--- a/src/server/cms/infra/repositories/strapi.fixture.ts
+++ b/src/server/cms/infra/repositories/strapi.fixture.ts
@@ -372,11 +372,9 @@ export function aStrapiArticleSlugList(): Strapi.CollectionType<Pick<Strapi.Coll
 	};
 }
 
-// TODO (BRUJ 14-06-2023): à changer après la mise en place du nouveau modèle de données
 export function anOffreDeStageResponse(override? : Partial<Strapi.CollectionType.OffreStage>): Strapi.CollectionType.OffreStage {
 	return {
 		createdAt: '2023-01-06T07:49:10.773Z',
-		dateDeDebut: '2024-09-01',
 		dateDeDebutMax: '2024-09-01',
 		dateDeDebutMin: '2024-09-01',
 		description: 'Poste ouvert aux personnes en situation de handicap',
@@ -415,10 +413,8 @@ export function anOffreDeStageResponse(override? : Partial<Strapi.CollectionType
 	};
 }
 
-// TODO (BRUJ 14-06-2023): à changer après la mise en place du nouveau modèle de données
 export function anOffreDeStageDepotStrapi(): Strapi.CollectionType.OffreStageDepot {
 	return {
-		dateDeDebut: '2023-02-03',
 		dateDeDebutMax: '2023-02-03',
 		dateDeDebutMin: '2023-02-03',
 		description: 'Vous assurez la préparation des commandes clients en prélevant les produits dans les emplacements via le système informatique Vous prenez en charge la réception, le déchargement, le réapprovisionnement des produit Vous gérez la réception des commandes par les clients Vous veillez au rangement et à la propreté de la zone de travail',

--- a/src/server/cms/infra/repositories/strapi.mapper.test.ts
+++ b/src/server/cms/infra/repositories/strapi.mapper.test.ts
@@ -47,6 +47,45 @@ describe('mapVideoCampagneApprentissage', () => {
 
 describe('mapOffreDeStage', () => {
 	it('map vers une offre de stage à afficher', () => {
+		const offreDeStageResponse: Strapi.CollectionType.OffreStage = {
+			createdAt: '2023-01-06T07:49:10.773Z',
+			dateDeDebutMax: '2024-09-01',
+			dateDeDebutMin: '2024-09-01',
+			description: 'Poste ouvert aux personnes en situation de handicap',
+			domaines: [],
+			dureeEnJour: 720,
+			dureeEnJourMax: 800,
+			employeur: {
+				description: null,
+				email: null,
+				logoUrl: null,
+				nom: 'La Relève',
+				siteUrl: null,
+			},
+			id: 'anId',
+			identifiantSource: '036780b7-95ba-4711-bf26-471d1f95051c',
+			localisation: {
+				adresse: null,
+				codePostal: null,
+				departement: null,
+				pays: 'France',
+				region: null,
+				ville: null,
+			},
+			publishedAt: '2023-01-06T07:49:10.756Z',
+			remunerationBase: 1000,
+			slug: 'alternance-audit-tours-h-f-036780b7-95ba-4711-bf26-471d1f95051c',
+			source: 'jobteaser' as SourceDesDonnées,
+			sourceCreatedAt: '',
+			sourcePublishedAt: '',
+			sourceUpdatedAt: '',
+			teletravailPossible: true,
+			titre: 'Alternance Audit - Tours ( H/F)',
+			updatedAt: '2023-01-06T07:49:10.773Z',
+			urlDeCandidature: 'https://www.jobteaser.com/en/job-offers/10067252',
+		};
+		
+		
 		const result: OffreDeStage = mapOffreStage(anOffreDeStageResponse());
 		const expectedResult: OffreDeStage = {
 			dateDeDebutMax: '2024-09-01',
@@ -80,35 +119,8 @@ describe('mapOffreDeStage', () => {
 				],
 			};
 			const result = mapOffreStage(anOffreDeStageResponse(domainesAvecUnDomaineNonRenseigne));
-			const expectedResult: OffreDeStage = {
-				dateDeDebutMax: '2024-09-01',
-				dateDeDebutMin: '2024-09-01',
-				description: 'Poste ouvert aux personnes en situation de handicap',
-				domaines: [Domaines.ACHAT],
-				dureeEnJour: 720,
-				dureeEnJourMax: 800,
-				employeur: {
-					description: undefined,
-					logoUrl: undefined,
-					nom: 'La Relève',
-					siteUrl: undefined,
-				},
-				id: 'anId',
-				localisation: {
-					codePostal: undefined,
-					departement: undefined,
-					pays: 'France',
-					region: undefined,
-					ville: undefined,
-				},
-				remunerationBase: 1000,
-				slug: 'alternance-audit-tours-h-f-036780b7-95ba-4711-bf26-471d1f95051c',
-				source: SourceDesDonnées.JOBTEASER,
-				teletravailPossible: true,
-				titre: 'Alternance Audit - Tours ( H/F)',
-				urlDeCandidature: 'https://www.jobteaser.com/en/job-offers/10067252',
-			};
-			expect(result).toStrictEqual(expectedResult);
+
+			expect(result.domaines).toStrictEqual([Domaines.ACHAT]);
 		});
 	});
 });

--- a/src/server/cms/infra/repositories/strapi.mapper.test.ts
+++ b/src/server/cms/infra/repositories/strapi.mapper.test.ts
@@ -86,7 +86,7 @@ describe('mapOffreDeStage', () => {
 		};
 		
 		
-		const result: OffreDeStage = mapOffreStage(anOffreDeStageResponse());
+		const result: OffreDeStage = mapOffreStage(offreDeStageResponse);
 		const expectedResult: OffreDeStage = {
 			dateDeDebutMax: '2024-09-01',
 			dateDeDebutMin: '2024-09-01',

--- a/src/server/cms/infra/repositories/strapi.mapper.test.ts
+++ b/src/server/cms/infra/repositories/strapi.mapper.test.ts
@@ -1,10 +1,6 @@
-import {
-	anOffreDeStageResponse,
-} from '~/server/cms/infra/repositories/strapi.fixture';
-import {
-	mapOffreStage,
-	mapVideoCampagneApprentissage,
-} from '~/server/cms/infra/repositories/strapi.mapper';
+import { Domaines, OffreDeStage, SourceDesDonnées } from '~/server/cms/domain/offreDeStage.type';
+import { anOffreDeStageResponse } from '~/server/cms/infra/repositories/strapi.fixture';
+import { mapOffreStage, mapVideoCampagneApprentissage } from '~/server/cms/infra/repositories/strapi.mapper';
 import { Strapi } from '~/server/cms/infra/repositories/strapi.response';
 
 describe('mapVideoCampagneApprentissage', () => {
@@ -49,13 +45,12 @@ describe('mapVideoCampagneApprentissage', () => {
 	});
 });
 
-
-// TODO (BRUJ 14-06-2023): à changer après la mise en place du nouveau modèle de données
 describe('mapOffreDeStage', () => {
-	it('lorsque la dateDeDebutMin n‘est pas fournie mais que la dateDeDebut l‘est, renvoie la dateDeDebut', () => {
-		const result = mapOffreStage(anOffreDeStageResponse({ dateDeDebutMin: undefined }));
-		const expectedResult = {
-			dateDeDebut: '2024-09-01',
+	it('map vers une offre de stage à afficher', () => {
+		const result: OffreDeStage = mapOffreStage(anOffreDeStageResponse());
+		const expectedResult: OffreDeStage = {
+			dateDeDebutMax: '2024-09-01',
+			dateDeDebutMin: '2024-09-01',
 			description: 'Poste ouvert aux personnes en situation de handicap',
 			domaines: [],
 			dureeEnJour: 720,
@@ -69,35 +64,51 @@ describe('mapOffreDeStage', () => {
 			},
 			remunerationBase: 1000,
 			slug: 'alternance-audit-tours-h-f-036780b7-95ba-4711-bf26-471d1f95051c',
-			source: 'jobteaser',
+			source: SourceDesDonnées.JOBTEASER,
 			teletravailPossible: true,
 			titre: 'Alternance Audit - Tours ( H/F)',
 			urlDeCandidature: 'https://www.jobteaser.com/en/job-offers/10067252',
 		};
 		expect(result).toEqual(expectedResult);
 	});
-	it('lorsque la dateDeDebut n‘est pas fournie mais que la dateDeDebutMin l‘est, renvoie la dateDeDebutMin', () => {
-		const result = mapOffreStage(anOffreDeStageResponse({ dateDeDebut: undefined }));
-		const expectedResult = {
-			dateDeDebut: '2024-09-01',
-			description: 'Poste ouvert aux personnes en situation de handicap',
-			domaines: [],
-			dureeEnJour: 720,
-			dureeEnJourMax: 800,
-			employeur: {
-				nom: 'La Relève',
-			},
-			id: 'anId',
-			localisation: {
-				pays: 'France',
-			},
-			remunerationBase: 1000,
-			slug: 'alternance-audit-tours-h-f-036780b7-95ba-4711-bf26-471d1f95051c',
-			source: 'jobteaser',
-			teletravailPossible: true,
-			titre: 'Alternance Audit - Tours ( H/F)',
-			urlDeCandidature: 'https://www.jobteaser.com/en/job-offers/10067252',
-		};
-		expect(result).toEqual(expectedResult);
+	describe('pour les domaines associés au stage', () => {
+		it('ne prend pas en compte le domaine "Non renseigné"', () => {
+			const domainesAvecUnDomaineNonRenseigne = {
+				domaines: [
+					{ nom: Strapi.CollectionType.OffreStage.Domaines.Nom.ACHAT },
+					{ nom: Strapi.CollectionType.OffreStage.Domaines.Nom.NON_RENSEIGNE },
+				],
+			};
+			const result = mapOffreStage(anOffreDeStageResponse(domainesAvecUnDomaineNonRenseigne));
+			const expectedResult: OffreDeStage = {
+				dateDeDebutMax: '2024-09-01',
+				dateDeDebutMin: '2024-09-01',
+				description: 'Poste ouvert aux personnes en situation de handicap',
+				domaines: [Domaines.ACHAT],
+				dureeEnJour: 720,
+				dureeEnJourMax: 800,
+				employeur: {
+					description: undefined,
+					logoUrl: undefined,
+					nom: 'La Relève',
+					siteUrl: undefined,
+				},
+				id: 'anId',
+				localisation: {
+					codePostal: undefined,
+					departement: undefined,
+					pays: 'France',
+					region: undefined,
+					ville: undefined,
+				},
+				remunerationBase: 1000,
+				slug: 'alternance-audit-tours-h-f-036780b7-95ba-4711-bf26-471d1f95051c',
+				source: SourceDesDonnées.JOBTEASER,
+				teletravailPossible: true,
+				titre: 'Alternance Audit - Tours ( H/F)',
+				urlDeCandidature: 'https://www.jobteaser.com/en/job-offers/10067252',
+			};
+			expect(result).toStrictEqual(expectedResult);
+		});
 	});
 });

--- a/src/server/cms/infra/repositories/strapi.mapper.ts
+++ b/src/server/cms/infra/repositories/strapi.mapper.ts
@@ -161,7 +161,6 @@ function flatMapSingleImage(response: Strapi.SingleRelation<Strapi.Image> | unde
 	};
 }
 
-// TODO (BRUJ 14-06-2023): à changer après la mise en place du nouveau modèle de données
 export function mapOffreStage(response: Strapi.CollectionType.OffreStage): OffreDeStage {
 	return {
 		dateDeDebutMax: response.dateDeDebutMax,

--- a/src/server/cms/infra/repositories/strapi.mapper.ts
+++ b/src/server/cms/infra/repositories/strapi.mapper.ts
@@ -164,7 +164,8 @@ function flatMapSingleImage(response: Strapi.SingleRelation<Strapi.Image> | unde
 // TODO (BRUJ 14-06-2023): à changer après la mise en place du nouveau modèle de données
 export function mapOffreStage(response: Strapi.CollectionType.OffreStage): OffreDeStage {
 	return {
-		dateDeDebut: response.dateDeDebut || response.dateDeDebutMin,
+		dateDeDebutMax: response.dateDeDebutMax,
+		dateDeDebutMin: response.dateDeDebutMin,
 		description: response.description,
 		domaines: response.domaines
 			.filter((domaine) => domaine.nom !== Strapi.CollectionType.OffreStage.Domaines.Nom.NON_RENSEIGNE)
@@ -249,10 +250,8 @@ export function mapAnnonceLogement(annonceLogementResponse: Strapi.CollectionTyp
 	};
 }
 
-// TODO (BRUJ 14-06-2023): à changer après la mise en place du nouveau modèle de données
 export function mapEnregistrerOffreDeStage(body: OffreDeStageDepot): Strapi.CollectionType.OffreStageDepot {
 	return {
-		dateDeDebut: body.dateDeDebut,
 		dateDeDebutMax: body.dateDeDebutMax,
 		dateDeDebutMin: body.dateDeDebutMin,
 		description: body.description,

--- a/src/server/cms/infra/repositories/strapi.response.ts
+++ b/src/server/cms/infra/repositories/strapi.response.ts
@@ -178,12 +178,10 @@ export namespace Strapi {
 			}
 		}
 
-	// TODO (BRUJ 14-06-2023): à changer après la mise en place du nouveau modèle de données
 		export interface OffreStage {
 			titre: string
 			id: string
 			slug: string
-			dateDeDebut: string
 			dateDeDebutMin: string
 			dateDeDebutMax: string
 			createdAt: string
@@ -272,9 +270,8 @@ export namespace Strapi {
 			}
 		}
 
-		// TODO (BRUJ 14-06-2023): à changer après la mise en place du nouveau modèle de données
 		export type OffreStageDepot =
-			Pick<OffreStage, 'dateDeDebut' | 'dateDeDebutMin' | 'dateDeDebutMax' | 'description' | 'domaines' | 'dureeEnJour' | 'remunerationBase' | 'teletravailPossible' | 'titre'>
+			Pick<OffreStage, 'dateDeDebutMin' | 'dateDeDebutMax' | 'description' | 'domaines' | 'dureeEnJour' | 'remunerationBase' | 'teletravailPossible' | 'titre'>
 			& {
 			identifiantSource: string;
 			publishedAt: null;


### PR DESCRIPTION
Wording modifié sur la carte d'offre de stage et sur la page détail d'une offre de stage
Des tests (en plus des tests sur la date de début min/max) ont été ajouté pour bien vérifier les quelques logiques dans le composant qui n'étaient pas testées.
Le ménage sur l'utilisation de la `dateDeDebut` a été commencé : sur toute la partie affichage d'une offre de stage, il ne devrait plus y avoir d'utilisation de `dateDeDebut`.
Par contre, le ménage reste à faire sur la partie dépôt de stage par un employeur 
 

- [ ] Merger cette PR après avoir mergé la PR meilisearch https://github.com/DNUM-SocialGouv/1j1s-main-cms/pull/142 (la review app ne pourra se faire qu'avec la PR meillisearch déployée en recette)

⚠️ MEP : cela implique de mettre en prod le CMS avant le front 