### PR TITLE
chore(renovate): activer auto merge de branche de mise à jour de patch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,15 @@
 {
   "enabled": true,
-  "extends": ["github>SocialGouv/renovate-config"]
+  "extends": ["github>SocialGouv/renovate-config"],
+  "separateMinorPatch": true,
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "branch",
+      "labels": ["automerge"]
+    }
+  ],
+  "platformAutomerge": true
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,6 @@
       "matchUpdateTypes": ["patch"],
       "automerge": true,
       "automergeType": "branch",
-      "labels": ["automerge"]
     }
   ],
   "platformAutomerge": true

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Run build for PR on main
+name: Run build
 
 on:
   push:

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -8,6 +8,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  create:
+    branches: [ "renovate/**" ]
 
 jobs:
   build:

--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -7,7 +7,7 @@
 # next a forcément besoin d'un fichier .env pour tourner du coup, on copie colle toutes les variables du serveur dedans
 # pas très propre, mais ça évite de les faire une par une à la mano
 
-name: Run e2e test for PR on main
+name: Run e2e test
 
 on:
   push:

--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -14,6 +14,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  create:
+    branches: [ "renovate/**" ]
 
 jobs:
   build:

--- a/.github/workflows/run-lint-and-unit-test.yml
+++ b/.github/workflows/run-lint-and-unit-test.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Run linter and unit test for ${{ github.ref }}
+name: Run linter and unit test
 
 on:
   push:

--- a/.github/workflows/run-lint-and-unit-test.yml
+++ b/.github/workflows/run-lint-and-unit-test.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Run linter and unit test for PR on main
+name: Run linter and unit test for ${{ github.ref }}
 
 on:
   push:

--- a/.github/workflows/run-lint-and-unit-test.yml
+++ b/.github/workflows/run-lint-and-unit-test.yml
@@ -8,6 +8,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  create:
+    branches: [ "renovate/**" ]
 
 jobs:
   build:


### PR DESCRIPTION
- activer les workflows de test sur la création de branche, 

- activer l’option automerge=true + automergeType=branch pour que Renovate puisse merger la branche sans passer par une PR (a nécessité l'activation de l’option `Allow specified actors to bypass required pull requests → renovate bot` dans Branch protection rules de main)

- Si les tests passent, la branche est bien mergée sans intervention humaine, sinon renovate créer une PR.