### PR TITLE
chore: changer le type de TagList pour Array<ReactNode>

### DIFF
--- a/src/client/components/features/OffreDeStage/Consulter/ConsulterOffreDeStage.tsx
+++ b/src/client/components/features/OffreDeStage/Consulter/ConsulterOffreDeStage.tsx
@@ -21,11 +21,14 @@ export function ConsulterOffreDeStage({ offreDeStage }: ConsulterOffreDeStagePro
 				.filter((domaine) => domaine !== DomainesStage.NON_RENSEIGNE)
 			: [];
 
-		const tags = [
+		const localisation = offreDeStage.localisation?.ville || offreDeStage.localisation?.departement || offreDeStage.localisation?.region;
+		const tags: Array<string> = [
 			...domainesWithoutNonRenseigne,
-			offreDeStage.localisation?.ville || offreDeStage.localisation?.departement || offreDeStage.localisation?.region,
-			dureeCategorisee(offreDeStage.dureeEnJour || 0),
 		];
+		if (localisation) {
+			tags.push(localisation);
+		}
+		tags.push(dureeCategorisee(offreDeStage.dureeEnJour || 0));
 		if (offreDeStage.dateDeDebutMin) {
 			tags.push(
 				offreDeStage.dateDeDebutMax && offreDeStage.dateDeDebutMin !== offreDeStage.dateDeDebutMax

--- a/src/client/components/layouts/RechercherSolution/Résultat/RésultatRechercherSolution.tsx
+++ b/src/client/components/layouts/RechercherSolution/Résultat/RésultatRechercherSolution.tsx
@@ -13,7 +13,7 @@ type RésultatRechercherSolutionProps = {
 	intituléOffre: string | ReactNode;
 	intituléLienOffre?: string;
 	sousTitreOffre?: string | ReactNode;
-	étiquetteOffreList: Array<string | undefined>;
+	étiquetteOffreList: Array<string>;
 } & React.HTMLAttributes<HTMLElement> & LogoProps;
 
 export function RésultatRechercherSolution(props: PropsWithChildren<RésultatRechercherSolutionProps>) {

--- a/src/client/components/ui/Tag/TagList.stories.tsx
+++ b/src/client/components/ui/Tag/TagList.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof TagList>;
 
 export const Example: Story = {
 	args: {
-		list: ['Ceci est un tag', 'Ceci est un autre tag'],
+		list: ['Ceci est un tag', 'Ceci est un autre tag', <a key="1" href={'https://1jeune1solution.gouv.fr'}> Ceci est un tag qui contient un lien</a>],
 	},
 };
 

--- a/src/client/components/ui/Tag/TagList.test.tsx
+++ b/src/client/components/ui/Tag/TagList.test.tsx
@@ -15,4 +15,12 @@ describe('TagList', () => {
 		expect(tags[0]).toHaveTextContent('element 1');
 		expect(tags[1]).toHaveTextContent('element 2');
 	});
+	it('filtre les tags vides', () => {
+		render(<TagList list={['element 1', '', 'element 2']}/>);
+
+		const tags = screen.getAllByRole('listitem');
+		expect(tags).toHaveLength(2);
+		expect(tags[0]).toHaveTextContent('element 1');
+		expect(tags[1]).toHaveTextContent('element 2');
+	});
 });

--- a/src/client/components/ui/Tag/TagList.test.tsx
+++ b/src/client/components/ui/Tag/TagList.test.tsx
@@ -15,13 +15,4 @@ describe('TagList', () => {
 		expect(tags[0]).toHaveTextContent('element 1');
 		expect(tags[1]).toHaveTextContent('element 2');
 	});
-
-	it('Supprime les éléments undefined', () => {
-		render(<TagList list={['element 1', undefined, 'element 2']}/>);
-
-		const tags = screen.getAllByRole('listitem');
-		expect(tags).toHaveLength(2);
-		expect(tags[0]).toHaveTextContent('element 1');
-		expect(tags[1]).toHaveTextContent('element 2');
-	});
 });

--- a/src/client/components/ui/Tag/TagList.tsx
+++ b/src/client/components/ui/Tag/TagList.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { Tag } from '~/client/components/ui/Tag/Tag';
 import styles from '~/client/components/ui/Tag/TagList.module.scss';
 
 interface TagListProps extends React.ComponentPropsWithoutRef<'ul'> {
-  list: Array<string>
+  list: Array<string | ReactNode>
 }
 
 export function TagList({ className, list, ...rest }: TagListProps) {
@@ -15,6 +15,7 @@ export function TagList({ className, list, ...rest }: TagListProps) {
 		<ul className={_classNames} {...rest}>
 			{
 				list
+					.filter((tag) => !!tag)
 					.map((tag, index) => (
 						<li key={`${tag}-${index}`}>
 							<Tag>{tag}</Tag>

--- a/src/client/components/ui/Tag/TagList.tsx
+++ b/src/client/components/ui/Tag/TagList.tsx
@@ -5,7 +5,7 @@ import { Tag } from '~/client/components/ui/Tag/Tag';
 import styles from '~/client/components/ui/Tag/TagList.module.scss';
 
 interface TagListProps extends React.ComponentPropsWithoutRef<'ul'> {
-  list: Array<string | ReactNode>
+  list: Array<ReactNode>
 }
 
 export function TagList({ className, list, ...rest }: TagListProps) {

--- a/src/client/components/ui/Tag/TagList.tsx
+++ b/src/client/components/ui/Tag/TagList.tsx
@@ -5,7 +5,7 @@ import { Tag } from '~/client/components/ui/Tag/Tag';
 import styles from '~/client/components/ui/Tag/TagList.module.scss';
 
 interface TagListProps extends React.ComponentPropsWithoutRef<'ul'> {
-  list: Array<string | undefined>
+  list: Array<string>
 }
 
 export function TagList({ className, list, ...rest }: TagListProps) {
@@ -15,7 +15,6 @@ export function TagList({ className, list, ...rest }: TagListProps) {
 		<ul className={_classNames} {...rest}>
 			{
 				list
-					.filter((tag) => !!tag)
 					.map((tag, index) => (
 						<li key={`${tag}-${index}`}>
 							<Tag>{tag}</Tag>


### PR DESCRIPTION
Passage directement à ReactNode (car on en aura besoin pour l'US qui demande d'ajouter un lien téléphonique dans les resultats des structures d'accompagnement) 