### PR TITLE
chore(form-init): suppression des champs non utilisés de l’objet API

### DIFF
--- a/src/server/formations-initiales/infra/formationInitialeResponse.fixture.ts
+++ b/src/server/formations-initiales/infra/formationInitialeResponse.fixture.ts
@@ -17,17 +17,12 @@ export function aResultatRechercheFormationInitialeApiResponse(override?: Partia
 export function aFormationInitialeApiResponse(override?: Partial<FormationInitialeApiResponse>): FormationInitialeApiResponse {
 	return {
 		code_nsf: '110',
-		code_rncp: '',
-		'domainesous-domaine': 'mécanique/automatismes | sciences/chimie | électricité, électronique, robotique/électronique | électricité, électronique, robotique/électrotechnique | mécanique/mécanique (généralités) | sciences/physique | électricité, électronique, robotique/télécommunications',
 		duree: '1 an',
 		libelle_formation_principal: 'Classe préparatoire Technologie et sciences industrielles (TSI), 2e année',
-		libelle_niveau_de_certification: 'niveau 5 (bac + 2)',
 		libelle_type_formation: 'classe préparatoire scientifique et technologique',
 		niveau_de_certification: '3',
 		niveau_de_sortie_indicatif: 'Bac + 2',
-		sigle_formation: '',
 		sigle_type_formation: 'CPGE',
-		tutelle: 'Ministère chargé de l\'Enseignement supérieur et de la Recherche',
 		url_et_id_onisep: 'http://www.onisep.fr/http/redirection/formation/slug/FOR.1234',
 		...override,
 	};

--- a/src/server/formations-initiales/infra/onisepFormationInitiale.repository.ts
+++ b/src/server/formations-initiales/infra/onisepFormationInitiale.repository.ts
@@ -17,16 +17,11 @@ export interface FormationInitialeApiResponse {
 	sigle_type_formation: string,
 	libelle_type_formation: string,
 	libelle_formation_principal: string,
-	sigle_formation: string,
 	duree: string,
 	niveau_de_sortie_indicatif: string,
-	code_rncp: string,
 	niveau_de_certification: string,
-	libelle_niveau_de_certification: string,
-	tutelle: string,
 	url_et_id_onisep: string,
-	'domainesous-domaine': string
-} // TODO fin dev formation-initiale : supprimer les champs dont on a pas besoin
+}
 
 export interface ResultatRechercheFormationInitialeApiResponse {
 	total: number


### PR DESCRIPTION
Objet de cette PR : supprimer les champs inutiles dans notre contexte de l'api onisep pour les formations initiales 