### PR TITLE
chore(service-jeune): suppression des champs non utilisés

### DIFF
--- a/src/server/services-jeunes/domain/servicesJeunes.fixture.ts
+++ b/src/server/services-jeunes/domain/servicesJeunes.fixture.ts
@@ -1,18 +1,14 @@
-import { anArticle } from '~/server/articles/domain/article.fixture';
 import { anImage } from '~/server/cms/domain/image.fixture';
 import { ServiceJeune } from '~/server/services-jeunes/domain/servicesJeunes';
 
 export function aServiceJeune(override?: Partial<ServiceJeune>): ServiceJeune {
 	return {
-		article: anArticle(),
 		banniere: anImage(),
 		categorie: ServiceJeune.Categorie.ACCOMPAGNEMENT,
 		concerne: 'pour les 12 à 18mois',
 		contenu: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.',
-		extraitContenu: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s …',
 		link: '/articles/aide-a-l-embauche-d-un-jeune-en-parcours-emploi-competences-pec-jeunes-dans-le-secteur-non-marchand',
 		titre: 'Un titre de carte',
-		url: 'Une belle url de carte',
 		...override,
 	};
 }
@@ -41,8 +37,6 @@ export function anUnorderedAndNotFilterServiceJeuneList(): Array<ServiceJeune> {
 			concerne: 'pour les 12 à 18mois',
 			contenu: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.',
 			titre: 'Une formation en centre EPIDE',
-			url: 'Une belle url de carte',
-
 		}),
 		aServiceJeune({
 			categorie: ServiceJeune.Categorie.AIDES_FINANCIERES,

--- a/src/server/services-jeunes/domain/servicesJeunes.fixture.ts
+++ b/src/server/services-jeunes/domain/servicesJeunes.fixture.ts
@@ -6,7 +6,6 @@ export function aServiceJeune(override?: Partial<ServiceJeune>): ServiceJeune {
 		banniere: anImage(),
 		categorie: ServiceJeune.Categorie.ACCOMPAGNEMENT,
 		concerne: 'pour les 12 à 18mois',
-		contenu: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.',
 		link: '/articles/aide-a-l-embauche-d-un-jeune-en-parcours-emploi-competences-pec-jeunes-dans-le-secteur-non-marchand',
 		titre: 'Un titre de carte',
 		...override,
@@ -35,7 +34,6 @@ export function anUnorderedAndNotFilterServiceJeuneList(): Array<ServiceJeune> {
 		aServiceJeune({
 			categorie: ServiceJeune.Categorie.ACCOMPAGNEMENT,
 			concerne: 'pour les 12 à 18mois',
-			contenu: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.',
 			titre: 'Une formation en centre EPIDE',
 		}),
 		aServiceJeune({

--- a/src/server/services-jeunes/domain/servicesJeunes.ts
+++ b/src/server/services-jeunes/domain/servicesJeunes.ts
@@ -1,16 +1,12 @@
-import { Article } from '~/server/articles/domain/article';
 import { Image } from '~/server/cms/domain/image';
 
 export interface ServiceJeune {
 	titre: string
 	categorie?: string
-	contenu: string
+	contenu: string //todo à supprimer aussi ?
 	banniere?: Image
-	url: string // FIXME ne sert à rien ?
-	article?: Article
 	concerne: string
 	link: string
-	extraitContenu: string
 }
 
 export namespace ServiceJeune {

--- a/src/server/services-jeunes/domain/servicesJeunes.ts
+++ b/src/server/services-jeunes/domain/servicesJeunes.ts
@@ -3,7 +3,6 @@ import { Image } from '~/server/cms/domain/image';
 export interface ServiceJeune {
 	titre: string
 	categorie?: string
-	contenu: string //todo à supprimer aussi ?
 	banniere?: Image
 	concerne: string
 	link: string

--- a/src/server/services-jeunes/infra/strapiServicesJeunes.mapper.test.ts
+++ b/src/server/services-jeunes/infra/strapiServicesJeunes.mapper.test.ts
@@ -19,7 +19,6 @@ describe('mapToServicesJeunes', () => {
 			accompagnement: [aStrapiMesureJeune({
 				article: aStrapiSingleRelation(aStrapiArticle()),
 				banniere: aStrapiSingleRelation(aStrapiImage()),
-				contenu: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.',
 				pourQui: 'pour les 12 à 18mois',
 				titre: 'Une formation en centre EPIDE',
 			})],

--- a/src/server/services-jeunes/infra/strapiServicesJeunes.mapper.test.ts
+++ b/src/server/services-jeunes/infra/strapiServicesJeunes.mapper.test.ts
@@ -1,13 +1,14 @@
-import { anArticle } from '~/server/articles/domain/article.fixture';
 import { aStrapiArticle } from '~/server/articles/infra/strapiArticle.fixture';
 import { anImage } from '~/server/cms/domain/image.fixture';
 import { aStrapiImage, aStrapiSingleRelation } from '~/server/cms/infra/repositories/strapi.fixture';
 import {
-	anUnorderedAndNotFilterServiceJeuneList, aServiceJeune,
+	anUnorderedAndNotFilterServiceJeuneList,
+	aServiceJeune,
 } from '~/server/services-jeunes/domain/servicesJeunes.fixture';
 import {
 	aStrapiMesureJeune,
-	aStrapiMesuresJeunesParCategorie, aStrapiMesuresJeunesParCategorieSansResultat,
+	aStrapiMesuresJeunesParCategorie,
+	aStrapiMesuresJeunesParCategorieSansResultat,
 } from '~/server/services-jeunes/infra/strapiMesuresJeunes.fixture';
 import { mapToServicesJeunes } from '~/server/services-jeunes/infra/strapiServicesJeunes.mapper';
 
@@ -21,7 +22,6 @@ describe('mapToServicesJeunes', () => {
 				contenu: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.',
 				pourQui: 'pour les 12 à 18mois',
 				titre: 'Une formation en centre EPIDE',
-				url: 'Une belle url de carte',
 			})],
 			aidesFinancieres: [aStrapiMesureJeune({
 				titre: 'Des aides pour financer son permis de conduire',
@@ -56,7 +56,6 @@ describe('mapToServicesJeunes', () => {
 
 			// THEN
 			expect(result).toStrictEqual([aServiceJeune({
-				article: undefined,
 				link: 'Une belle url de carte',
 			})]);
 		});
@@ -73,7 +72,6 @@ describe('mapToServicesJeunes', () => {
 
 			// THEN
 			expect(result).toStrictEqual([aServiceJeune({
-				article: anArticle({ slug: 'this-is-a-slug' }),
 				link: '/articles/this-is-a-slug',
 			})]);
 		});

--- a/src/server/services-jeunes/infra/strapiServicesJeunes.mapper.ts
+++ b/src/server/services-jeunes/infra/strapiServicesJeunes.mapper.ts
@@ -29,7 +29,6 @@ function mapServiceJeune(response: StrapiMesuresJeunes.MesureJeune, categorie: S
 		},
 		categorie: mapServiceJeuneCategorie(categorie),
 		concerne: response.pourQui,
-		contenu: response.contenu,
 		link: article ? `/articles/${article.slug}` : response.url,
 		titre: response.titre,
 	};

--- a/src/server/services-jeunes/infra/strapiServicesJeunes.mapper.ts
+++ b/src/server/services-jeunes/infra/strapiServicesJeunes.mapper.ts
@@ -1,9 +1,5 @@
 import { StrapiArticle } from '~/server/articles/infra/strapiArticle';
-import { mapArticle } from '~/server/articles/infra/strapiArticle.mapper';
-import {
-	flatMapSingleRelation,
-	getExtraitContenu,
-} from '~/server/cms/infra/repositories/strapi.mapper';
+import { flatMapSingleRelation } from '~/server/cms/infra/repositories/strapi.mapper';
 import { Strapi } from '~/server/cms/infra/repositories/strapi.response';
 import { ServiceJeune } from '~/server/services-jeunes/domain/servicesJeunes';
 import { StrapiMesuresJeunes } from '~/server/services-jeunes/infra/strapiMesuresJeunes';
@@ -27,7 +23,6 @@ function mapServiceJeune(response: StrapiMesuresJeunes.MesureJeune, categorie: S
 	const banniere = flatMapSingleRelation<Strapi.Image>(response.banniere);
 
 	return {
-		article: article && mapArticle(article),
 		banniere: banniere && {
 			alt: banniere.alternativeText || '',
 			src: banniere.url,
@@ -35,10 +30,8 @@ function mapServiceJeune(response: StrapiMesuresJeunes.MesureJeune, categorie: S
 		categorie: mapServiceJeuneCategorie(categorie),
 		concerne: response.pourQui,
 		contenu: response.contenu,
-		extraitContenu: getExtraitContenu(response.contenu, 110),
 		link: article ? `/articles/${article.slug}` : response.url,
 		titre: response.titre,
-		url: response.url,
 	};
 }
 


### PR DESCRIPTION
Aujourd'hui, le type ServiceJeune embarque plus de choses que ce qui lui est nécessaire pour l'affichage de la carte ServiceJeune. 
Cette PR a pour but de supprimer ces champs du mapper pour simplifier le type et le traitement