### PR TITLE
chore(mesure-employeur): suppression des champs non utilisés

### DIFF
--- a/src/client/components/features/MesuresEmployeurs/MesuresEmployeurs.tsx
+++ b/src/client/components/features/MesuresEmployeurs/MesuresEmployeurs.tsx
@@ -28,7 +28,7 @@ export function MesuresEmployeursComponent({ mesureEmployeurList }: MesuresEmplo
 				<section className={styles.dispositifs}>
 					<ul className={styles.cartes} aria-labelledby="dispositifs">
 						{mesureEmployeurList.map((carte) => (
-							<li key={carte.url}>
+							<li key={carte.titre}>
 								<CarteMesureEmployeur carte={carte} isMobile={isMobile}/>
 							</li>
 						))}

--- a/src/server/mesures-employeurs/domain/mesureEmployeur.fixture.ts
+++ b/src/server/mesures-employeurs/domain/mesureEmployeur.fixture.ts
@@ -1,20 +1,13 @@
-import { anArticle } from '~/server/articles/domain/article.fixture';
 import { anImage } from '~/server/cms/domain/image.fixture';
 
 import { MesureEmployeur } from './mesureEmployeur';
 
 export function aMesureEmployeur(override?: Partial<MesureEmployeur>): MesureEmployeur {
 	return {
-		article: anArticle({
-			slug: 'aide-a-l-embauche-d-un-jeune-en-parcours-emploi-competences-pec-jeunes-dans-le-secteur-non-marchand',
-		}),
 		banniere: anImage(),
-		contenu: 'Un beau contenu de carte',
-		extraitContenu: 'Un beau contenu de carte',
 		link: '/articles/aide-a-l-embauche-d-un-jeune-en-parcours-emploi-competences-pec-jeunes-dans-le-secteur-non-marchand',
 		pourQui: 'Ceci est pour tous ceux à qui ça s‘adresse',
 		titre: 'Un titre de carte',
-		url: 'https://some.example.com/1',
 		...override,
 	};
 }
@@ -23,34 +16,22 @@ export function aMesuresEmployeursList(): Array<MesureEmployeur> {
 	return [
 		aMesureEmployeur(),
 		aMesureEmployeur({
-			article: anArticle({ slug: 'slug-article' }),
 			banniere: anImage(),
-			contenu: 'Un deuxième beau contenu de carte',
-			extraitContenu: 'Un deuxième beau contenu de carte',
 			link: '/articles/slug-article',
 			pourQui: 'Ceci est pour tous ceux à qui ça s‘adresse',
 			titre: 'Un deuxième titre de carte',
-			url: 'https://some.example.com/2',
 		}),
 		aMesureEmployeur({
-			article: anArticle({ slug: 'titre' }),
 			banniere: anImage(),
-			contenu: 'Un troisième beau contenu de carte',
-			extraitContenu: 'Un troisième beau contenu de carte',
 			link: '/articles/titre',
 			pourQui: 'Ceci est pour tous ceux à qui ça s‘adresse',
 			titre: 'Un troisième titre de carte',
-			url: 'https://some.example.com/3',
 		}),
 		aMesureEmployeur({
-			article: anArticle({ slug: 'titre' }),
 			banniere: anImage(),
-			contenu: 'Un quatrième beau contenu de carte',
-			extraitContenu: 'Un quatrième beau contenu de carte',
 			link: '/articles/titre',
 			pourQui: 'Ceci est pour tous ceux à qui ça s‘adresse',
 			titre: 'Un quatrième titre de carte',
-			url: 'https://some.example.com/4',
 		}),
 	];
 }

--- a/src/server/mesures-employeurs/domain/mesureEmployeur.ts
+++ b/src/server/mesures-employeurs/domain/mesureEmployeur.ts
@@ -1,14 +1,9 @@
-import { Article } from '~/server/articles/domain/article';
 import { Image } from '~/server/cms/domain/image';
 
 export interface MesureEmployeur {
   titre: string
-  contenu: string
   banniere?: Image
-  url?: string
-  article?: Article
   pourQui: string
   link: string
-  extraitContenu: string
 }
 

--- a/src/server/mesures-employeurs/infra/strapiMesuresEmployeurs.mapper.test.ts
+++ b/src/server/mesures-employeurs/infra/strapiMesuresEmployeurs.mapper.test.ts
@@ -1,10 +1,7 @@
-import { anArticle } from '~/server/articles/domain/article.fixture';
 import { aStrapiArticle } from '~/server/articles/infra/strapiArticle.fixture';
 import { anImage } from '~/server/cms/domain/image.fixture';
 import { aStrapiImage, aStrapiSingleRelation } from '~/server/cms/infra/repositories/strapi.fixture';
-import {
-	aMesureEmployeur,
-} from '~/server/mesures-employeurs/domain/mesureEmployeur.fixture';
+import { aMesureEmployeur } from '~/server/mesures-employeurs/domain/mesureEmployeur.fixture';
 import {
 	aStrapiMesureEmployeur,
 	aStrapiMesuresEmployeursList,
@@ -33,26 +30,16 @@ describe('mapMesuresEmployeurs', () => {
 		}));
 		const expectedMesuresEmployeurs = [
 			aMesureEmployeur({
-				article: anArticle({
-					slug: 'aide-a-l-embauche-d-un-jeune-en-parcours-emploi-competences-pec-jeunes-dans-le-secteur-non-marchand',
-				}),
 				banniere: anImage(),
-				contenu: 'Un beau contenu de carte',
-				extraitContenu: 'Un beau contenu de carte',
 				link: '/articles/aide-a-l-embauche-d-un-jeune-en-parcours-emploi-competences-pec-jeunes-dans-le-secteur-non-marchand',
 				pourQui: 'Ceci est pour tous ceux à qui ça s‘adresse',
 				titre: 'Un titre de carte',
-				url: 'https://some.example.com/1',
 			}),
 			aMesureEmployeur({
-				article: anArticle({ slug: 'slug-article' }),
 				banniere: anImage(),
-				contenu: 'Un deuxième beau contenu de carte',
-				extraitContenu: 'Un deuxième beau contenu de carte',
 				link: '/articles/slug-article',
 				pourQui: 'Ceci est pour tous ceux à qui ça s‘adresse',
 				titre: 'Un deuxième titre de carte',
-				url: 'https://some.example.com/2',
 			}),
 		];
 
@@ -60,7 +47,7 @@ describe('mapMesuresEmployeurs', () => {
 	});
 
 	describe('article', () => {
-		it('lorsqu‘aucun article est relié, ne renvoie pas d‘article et renvoie en link l‘url associée à la mesure employeur', () => {
+		it('lorsqu‘aucun article est relié, renvoie en link l‘url associée à la mesure employeur', () => {
 			// GIVEN
 			const strapiMesuresEmployeurs = aStrapiMesuresEmployeursList({
 				dispositifs: [aStrapiMesureEmployeur({
@@ -74,13 +61,11 @@ describe('mapMesuresEmployeurs', () => {
 
 			// THEN
 			expect(result).toStrictEqual([aMesureEmployeur({
-				article: undefined,
 				link: 'https://some.example.com/4',
-				url: 'https://some.example.com/4',
 			})]);
 		});
 
-		it('lorsqu‘un article est relié, renvoie les informations relatives à l‘article et un lien à partir du slug de l‘article', () => {
+		it('lorsqu‘un article est relié, renvoie un lien à partir du slug de l‘article', () => {
 			// GIVEN
 			const strapiMesuresEmployeurs = aStrapiMesuresEmployeursList({
 				dispositifs: [aStrapiMesureEmployeur({
@@ -93,7 +78,6 @@ describe('mapMesuresEmployeurs', () => {
 
 			// THEN
 			expect(result).toStrictEqual([aMesureEmployeur({
-				article: anArticle({ slug: 'this-is-a-slug' }),
 				link: '/articles/this-is-a-slug',
 			})]);
 		});

--- a/src/server/mesures-employeurs/infra/strapiMesuresEmployeurs.mapper.ts
+++ b/src/server/mesures-employeurs/infra/strapiMesuresEmployeurs.mapper.ts
@@ -1,9 +1,4 @@
-import { mapArticle } from '~/server/articles/infra/strapiArticle.mapper';
-import {
-	flatMapSingleImage,
-	flatMapSingleRelation,
-	getExtraitContenu,
-} from '~/server/cms/infra/repositories/strapi.mapper';
+import { flatMapSingleImage, flatMapSingleRelation } from '~/server/cms/infra/repositories/strapi.mapper';
 import { MesureEmployeur } from '~/server/mesures-employeurs/domain/mesureEmployeur';
 import { StrapiMesuresEmployeurs } from '~/server/mesures-employeurs/infra/strapiMesuresEmployeurs';
 
@@ -12,14 +7,10 @@ export function mapMesuresEmployeurs(strapiLesMesuresEmployeurs: StrapiMesuresEm
 		const article = strapiLesMesuresEmployeursDispositif.article && flatMapSingleRelation(strapiLesMesuresEmployeursDispositif.article);
 
 		return {
-			article: article && mapArticle(article),
 			banniere: flatMapSingleImage(strapiLesMesuresEmployeursDispositif.banniere),
-			contenu: strapiLesMesuresEmployeursDispositif.contenu,
-			extraitContenu: getExtraitContenu(strapiLesMesuresEmployeursDispositif.contenu, 110),
 			link: article ? `/articles/${article.slug}` : strapiLesMesuresEmployeursDispositif.url,
 			pourQui: strapiLesMesuresEmployeursDispositif.pourQui || '',
 			titre: strapiLesMesuresEmployeursDispositif.titre,
-			url: strapiLesMesuresEmployeursDispositif.url,
 		};
 	});
 }

--- a/src/server/mesures-employeurs/infra/strapiMesuresEmployeurs.repository.test.ts
+++ b/src/server/mesures-employeurs/infra/strapiMesuresEmployeurs.repository.test.ts
@@ -38,7 +38,7 @@ describe('StrapiMesuresEmployeursRepository', () => {
 
 			it('quand le mapping vers les mesures employeurs est en échec, appelle le service de management d‘erreur avec l‘erreur et le contexte', async () => {
 				const strapiService = aStrapiCmsRepository();
-				jest.spyOn(strapiService, 'getSingleType').mockResolvedValue(createSuccess({ dispositifs: [{}] }));
+				jest.spyOn(strapiService, 'getSingleType').mockResolvedValue(createSuccess({ someNonExistentField: '' }));
 
 				const errorManagementService = anErrorManagementService();
 				const failureFromErrorManagement = createFailure(ErreurMetier.DEMANDE_INCORRECTE);


### PR DESCRIPTION
Aujourd'hui, le type MesureEmployeur embarque plus de choses que ce qui lui est nécessaire pour l'affichage de la carte MesureEmployeur.
Cette PR a pour but de supprimer ces champs du mapper pour simplifier le type et le traitement