### PR TITLE
feat(formulaires): a11y ajouter les attributs autocomplete sur les formulaires quand c'est pertinent

### DIFF
--- a/src/client/components/features/ContratEngagementJeune/FormulaireContactCEJ/FormulaireContactCEJ.test.tsx
+++ b/src/client/components/features/ContratEngagementJeune/FormulaireContactCEJ/FormulaireContactCEJ.test.tsx
@@ -47,6 +47,18 @@ describe('<FormulaireDeContactCEJ />', () => {
 		expect(screen.getByRole('button', { name: 'Envoyer la demande' })).toBeVisible();
 	});
 
+	it('les champs contenant des informations personnels ont des autocomplete', async () => {
+		// When
+		renderComponent();
+
+		// Then
+		expect(screen.getByRole('textbox',{ name: 'Prénom Exemple : Jean' })).toHaveAttribute('autocomplete', 'given-name');
+		expect(screen.getByRole('textbox', { name: 'Nom Exemple : Dupont' })).toHaveAttribute('autocomplete', 'family-name');
+		expect(screen.getByRole('textbox', { name: 'Adresse e-mail Exemple : jean.dupont@gmail.com' })).toHaveAttribute('autocomplete', 'email');
+		expect(screen.getByRole('textbox', { name: 'Téléphone Exemple : 0606060606' })).toHaveAttribute('autocomplete', 'tel-national');
+	});
+
+
 	it('lorsque je remplis le champ email avec des espaces avant et après, ils sont pas pris en compte', async () => {
 		const user = userEvent.setup();
 

--- a/src/client/components/features/ContratEngagementJeune/FormulaireContactCEJ/FormulaireContactCEJ.tsx
+++ b/src/client/components/features/ContratEngagementJeune/FormulaireContactCEJ/FormulaireContactCEJ.tsx
@@ -59,7 +59,7 @@ export function FormulaireDeContactCEJ({ onSuccess, onFailure }: FormulaireDeCon
 					Prénom
 					<Champ.Label.Complement>Exemple : Jean</Champ.Label.Complement>
 				</Champ.Label>
-				<Champ.Input name="firstname" render={Input} required/>
+				<Champ.Input name="firstname" render={Input} required autoComplete="given-name"/>
 				<Champ.Error/>
 			</Champ>
 
@@ -68,7 +68,7 @@ export function FormulaireDeContactCEJ({ onSuccess, onFailure }: FormulaireDeCon
 					Nom
 					<Champ.Label.Complement>Exemple : Dupont</Champ.Label.Complement>
 				</Champ.Label>
-				<Champ.Input name="lastname" render={Input} required/>
+				<Champ.Input name="lastname" render={Input} required autoComplete="family-name"/>
 				<Champ.Error/>
 			</Champ>
 
@@ -77,7 +77,7 @@ export function FormulaireDeContactCEJ({ onSuccess, onFailure }: FormulaireDeCon
 					Adresse e-mail
 					<Champ.Label.Complement>Exemple : jean.dupont@gmail.com</Champ.Label.Complement>
 				</Champ.Label>
-				<Champ.Input name="mail" render={Input} required pattern={emailRegex} type="email"/>
+				<Champ.Input name="mail" render={Input} required pattern={emailRegex} type="email" autoComplete="email"/>
 				<Champ.Error/>
 			</Champ>
 
@@ -86,7 +86,7 @@ export function FormulaireDeContactCEJ({ onSuccess, onFailure }: FormulaireDeCon
 					Téléphone
 					<Champ.Label.Complement>Exemple : 0606060606</Champ.Label.Complement>
 				</Champ.Label>
-				<Champ.Input name="phone" render={Input} required pattern={telFrRegex} type="tel"/>
+				<Champ.Input name="phone" render={Input} required pattern={telFrRegex} type="tel" autoComplete="tel-national"/>
 				<Champ.Error/>
 			</Champ>
 

--- a/src/client/components/features/OffreDeStage/Déposer/Étape1Entreprise/StageDeposerOffreFormulaireÉtape1Entreprise.test.tsx
+++ b/src/client/components/features/OffreDeStage/Déposer/Étape1Entreprise/StageDeposerOffreFormulaireÉtape1Entreprise.test.tsx
@@ -31,6 +31,13 @@ describe('<Entreprise />', () => {
 			expect(screen.getByRole('button', { name: 'Suivant' })).toBeInTheDocument();
 		});
 
+		it('les champs contenant des données pouvant être saisie automatiquement ont un attribut autocomplete approprié', () => {
+			render(<Entreprise/>);
+
+			expect(screen.getByRole('textbox', { name: 'Nom de l’entreprise ou de l’employeur Exemples : Crédit Agricole, SNCF…' })).toHaveAttribute('autocomplete', 'organization');
+			expect(screen.getByRole('textbox', { name: 'Adresse mail de contact Exemple : contactRH@example.com' })).toHaveAttribute('autocomplete', 'email');
+		});
+
 		describe('champ adresse mail', () => {
 			it('le champ adresse mail donne une indication sur l’usage de celle-ci', async () => {
 				render(<Entreprise/>);

--- a/src/client/components/features/OffreDeStage/Déposer/Étape1Entreprise/StageDeposerOffreFormulaireÉtape1Entreprise.tsx
+++ b/src/client/components/features/OffreDeStage/Déposer/Étape1Entreprise/StageDeposerOffreFormulaireÉtape1Entreprise.tsx
@@ -46,7 +46,9 @@ export default function StageDeposerOffreFormulaireÉtape1Entreprise() {
 										 required
 										 type="text"
 										 maxLength={255}
-										 defaultValue={informationsEntreprise?.nomEmployeur}/>
+										 defaultValue={informationsEntreprise?.nomEmployeur}
+										 autoComplete="organization"
+				/>
 				<Champ.Error/>
 				<Champ.Hint>255 caractères maximum</Champ.Hint>
 			</Champ>
@@ -59,7 +61,9 @@ export default function StageDeposerOffreFormulaireÉtape1Entreprise() {
 										 pattern={emailRegex}
 										 defaultValue={informationsEntreprise?.emailEmployeur}
 										 required
-										 type="email"/>
+										 type="email"
+										 autoComplete="email"
+				/>
 				<Champ.Error/>
 				<Champ.Hint>
 					Cette adresse de contact sera utilisée dans le cas où

--- a/src/pages/les-entreprises-s-engagent/inscription/index.page.test.tsx
+++ b/src/pages/les-entreprises-s-engagent/inscription/index.page.test.tsx
@@ -90,6 +90,13 @@ describe('LesEntreprisesSEngagentInscription', () => {
 			});
 		});
 
+		it('le champ concernant le nom de l’entreprise possède un attribut autocomplete approprié', () => {
+			renderComponent();
+
+			const inputOrganizationName = screen.getByRole('textbox', { name: /Nom de l’entreprise/ });
+			expect(inputOrganizationName).toHaveAttribute('autocomplete', 'organization');
+		});
+
 		describe('champ secteur d‘activité', () => {
 			it('les secteurs d’activités sont triés par ordre alphabétique avec "autres" et "autres activités" à la fin', async () => {
 				const user = userEvent.setup();
@@ -164,6 +171,21 @@ describe('LesEntreprisesSEngagentInscription', () => {
 	});
 
 	describe('sur l‘étape 2', () => {
+		it('les champs nécessitant une auto-complétion ont un attribut autocomplete approprié', async () => {
+			// GIVEN
+			renderComponent();
+			await remplirFormulaireEtape1();
+
+			// WHEN
+			await clickOnGoToEtape2();
+
+			// THEN
+			expect(screen.getByRole('textbox', { name: /Prénom/ })).toHaveAttribute('autocomplete', 'given-name');
+			expect(screen.getByRole('textbox', { name: /Nom/ })).toHaveAttribute('autocomplete', 'family-name');
+			expect(screen.getByRole('textbox', { name: /Adresse e-mail de contact/ })).toHaveAttribute('autocomplete', 'email');
+			expect(screen.getByRole('textbox', { name: /Fonction au sein de l’entreprise/ })).toHaveAttribute('autocomplete', 'organization-title');
+		});
+
 		it('lorsqu‘il remplit le champ email avec des espaces avant et après, ils ne sont pas pris en compte', async () => {
 			const user = userEvent.setup();
 			renderComponent();

--- a/src/pages/les-entreprises-s-engagent/inscription/index.page.tsx
+++ b/src/pages/les-entreprises-s-engagent/inscription/index.page.tsx
@@ -169,7 +169,9 @@ export default function LesEntreprisesSEngagentInscription() {
 										<Champ.Input
 											render={Input}
 											name={'companyName'}
-											required/>
+											required
+											autoComplete="organization"
+										/>
 										<Champ.Error/>
 									</Champ>
 									<ComboboxCommune
@@ -250,7 +252,9 @@ export default function LesEntreprisesSEngagentInscription() {
 										<Champ.Input
 											render={Input}
 											name={'firstName'}
-											required/>
+											required
+											autoComplete="given-name"
+										/>
 										<Champ.Error/>
 									</Champ>
 
@@ -262,7 +266,9 @@ export default function LesEntreprisesSEngagentInscription() {
 										<Champ.Input
 											render={Input}
 											name={'lastName'}
-											required/>
+											required
+											autoComplete="family-name"
+										/>
 										<Champ.Error/>
 									</Champ>
 
@@ -276,7 +282,9 @@ export default function LesEntreprisesSEngagentInscription() {
 										<Champ.Input
 											render={Input}
 											name={'job'}
-											required/>
+											required
+											autoComplete="organization-title"
+										/>
 										<Champ.Error/>
 									</Champ>
 
@@ -292,7 +300,9 @@ export default function LesEntreprisesSEngagentInscription() {
 											type="email"
 											render={Input}
 											name={'email'}
-											required/>
+											required
+											autoComplete="email"
+										/>
 										<Champ.Hint>Cette adresse vous permettra d’accéder à votre espace sécurisé afin de gérer les
 											informations suivies.</Champ.Hint>
 										<Champ.Error/>


### PR DESCRIPTION
Formulaires en question : 
- contact CEJ 
- Les entreprises s'engagent 
- Depot d'offre de stage (nom entreprise + email, pas le reste des champs)

Voir à la revue s'il faut inclure email pro ou pas pour LEE et depot stage 