### PR TITLE
fix(logement): image en 429

### DIFF
--- a/src/client/components/features/Logement/Annonce.tsx
+++ b/src/client/components/features/Logement/Annonce.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import Image from 'next/image';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import styles from '~/client/components/features/Logement/Annonce.module.scss';
 import { AnnonceDeLogementIndexee } from '~/client/components/features/Logement/AnnonceDeLogementIndexee';
@@ -66,13 +66,14 @@ function CardImage(props: { imageSrcList: ImageSrcListProps }) {
 	const { imageSrcList } = props;
 	const hasNoImage = imageSrcList.length === 0;
 	const hasOnlyOneImage = imageSrcList.length === 1;
+	const [error, setError] = useState(false);
 
-	if (hasNoImage) return <div className={styles.CardImageWrapper}>
+	if (hasNoImage || error) return <div className={styles.CardImageWrapper}>
 		<Image src={'/images/image-par-defaut-carte.webp'} alt="" width={360} height={180}/>
 	</div>;
 
 	if (hasOnlyOneImage) return <div className={styles.CardImageWrapper}>
-		<Image src={imageSrcList[0]} alt="" width={360} height={180}/>
+		<Image src={imageSrcList[0]} onError={() => setError(true)} alt="" width={360} height={180}/>
 	</div>;
 
 	return <CardAnnonceCarousel imageSrcList={imageSrcList}/>;

--- a/src/client/components/features/Logement/Annonce.tsx
+++ b/src/client/components/features/Logement/Annonce.tsx
@@ -76,11 +76,11 @@ function CardImage(props: { imageSrcList: ImageSrcListProps }) {
 		<Image src={imageSrcList[0]} onError={() => setError(true)} alt="" width={360} height={180}/>
 	</div>;
 
-	return <CardAnnonceCarousel imageSrcList={imageSrcList}/>;
+	return <CardAnnonceCarousel imageSrcList={imageSrcList} onErrorImageLoading={() => setError(true)}/>;
 }
 
-const CardAnnonceCarousel = (props: { imageSrcList: ImageSrcListProps }) => {
-	const { imageSrcList } = props;
+const CardAnnonceCarousel = (props: { imageSrcList: ImageSrcListProps, onErrorImageLoading: () => void }) => {
+	const { imageSrcList, onErrorImageLoading } = props;
 	const formattedList = imageSrcList.map((src) => ({ alt: undefined, src }));
 	const MAX_IMAGE_WIDTH = 360;
 	const MAX_IMAGE_HEIGHT = 180;
@@ -92,6 +92,7 @@ const CardAnnonceCarousel = (props: { imageSrcList: ImageSrcListProps }) => {
 			className={styles.CardImageWrapper}
 			imagesSize={{ height: MAX_IMAGE_HEIGHT, width: MAX_IMAGE_WIDTH }}
 			aria-label="Photos du logement"
+			onErrorImageLoading={onErrorImageLoading}
 		/>
 	);
 };

--- a/src/client/components/ui/Carousel/Carousel.module.scss
+++ b/src/client/components/ui/Carousel/Carousel.module.scss
@@ -13,3 +13,7 @@
   }
 }
 
+.imageOnError {
+  height: 11.25rem;
+}
+

--- a/src/client/components/ui/Carousel/Carousel.tsx
+++ b/src/client/components/ui/Carousel/Carousel.tsx
@@ -31,6 +31,7 @@ export function Carousel(props: CarouselProps) {
 	const [isAnimated, setIsAnimated] = useState(true);
 	const isLastSlide = (currentSlideIndex + 1) === numberOfImages;
 	const isFirstSlide = currentSlideIndex === 0;
+	const [error, setError] = useState(false);
 
 	const goToPreviousSlide = useCallback(() => {
 		setIsAnimated(true);
@@ -54,10 +55,22 @@ export function Carousel(props: CarouselProps) {
 
 	if (numberOfImages === 0) return null;
 
+	if (error) {
+		return (
+			<Image
+				src={'/images/image-par-defaut-carte.webp'}
+				alt=""
+				width={360}
+				height={180}
+			/>
+		);
+	}
+
 	if (numberOfImages === 1) {
 		return (
 			<Image
 				src={imageList[0].src}
+				onError={() => setError(true)}
 				alt={imageList[0].alt || '1 sur 1'}
 				width={imagesSize.width}
 				height={imagesSize.height}
@@ -83,6 +96,7 @@ export function Carousel(props: CarouselProps) {
 						setDirection={setDirection}
 						isAnimated={isAnimated}
 						imagesSize={imagesSize}
+						setError={setError}
 					/>
 				))}
 			</ul>

--- a/src/client/components/ui/Carousel/Carousel.tsx
+++ b/src/client/components/ui/Carousel/Carousel.tsx
@@ -16,12 +16,13 @@ interface CarouselProps extends React.ComponentPropsWithoutRef<'div'> {
 	imageList: Array<ImageProps>
 	hideIndicators?: boolean
 	imagesSize: { width: number, height: number }
+	onErrorImageLoading?: () => void
 }
 
 export type Direction = 'next' | 'previous' | null;
 
 export function Carousel(props: CarouselProps) {
-	const { imageList, imagesSize, hideIndicators = false, className, ...rest } = props;
+	const { imageList, imagesSize, hideIndicators = false, className, onErrorImageLoading, ...rest } = props;
 	const _classNames = classNames(className, styles.carousel);
 	const numberOfImages = imageList.length;
 
@@ -31,7 +32,6 @@ export function Carousel(props: CarouselProps) {
 	const [isAnimated, setIsAnimated] = useState(true);
 	const isLastSlide = (currentSlideIndex + 1) === numberOfImages;
 	const isFirstSlide = currentSlideIndex === 0;
-	const [error, setError] = useState(false);
 
 	const goToPreviousSlide = useCallback(() => {
 		setIsAnimated(true);
@@ -55,23 +55,11 @@ export function Carousel(props: CarouselProps) {
 
 	if (numberOfImages === 0) return null;
 
-	if (error) {
-		return (
-			<Image
-				src={'/images/image-par-defaut-carte.webp'}
-				alt=""
-				width={360}
-				height={180}
-				className={styles.imageOnError}
-			/>
-		);
-	}
-
 	if (numberOfImages === 1) {
 		return (
 			<Image
 				src={imageList[0].src}
-				onError={() => setError(true)}
+				onError={onErrorImageLoading}
 				alt={imageList[0].alt || '1 sur 1'}
 				width={imagesSize.width}
 				height={imagesSize.height}
@@ -97,7 +85,7 @@ export function Carousel(props: CarouselProps) {
 						setDirection={setDirection}
 						isAnimated={isAnimated}
 						imagesSize={imagesSize}
-						setError={setError}
+						onErrorImageLoading={onErrorImageLoading}
 					/>
 				))}
 			</ul>

--- a/src/client/components/ui/Carousel/Carousel.tsx
+++ b/src/client/components/ui/Carousel/Carousel.tsx
@@ -62,6 +62,7 @@ export function Carousel(props: CarouselProps) {
 				alt=""
 				width={360}
 				height={180}
+				className={styles.imageOnError}
 			/>
 		);
 	}

--- a/src/client/components/ui/Carousel/Slide.tsx
+++ b/src/client/components/ui/Carousel/Slide.tsx
@@ -20,7 +20,7 @@ interface SlideProps {
 	setDirection: (direction: Direction) => void
 	isAnimated: boolean
 	imagesSize: { width: number, height: number }
-	setError: (value: boolean) => void
+	onErrorImageLoading?: () => void
 }
 
 export function defaultAlternative(index: number, numberOfImages: number) {
@@ -41,7 +41,7 @@ export const Slide = (props: SlideProps) => {
 		setDirection,
 		isAnimated,
 		imagesSize,
-		setError,
+		onErrorImageLoading,
 	} = props;
 
 	const isCurrentSlide = useMemo(() => index === currentSlideIndex, [index, currentSlideIndex]);
@@ -70,7 +70,7 @@ export const Slide = (props: SlideProps) => {
 				{ [styles.transition]: isAnimated },
 			)}
 		>
-			<Image src={image.src} onError={() => setError(true)} alt={image.alt || defaultAlternative(index, numberOfImages)} width={imagesSize.width} height={imagesSize.height} />
+			<Image src={image.src} onError={onErrorImageLoading} alt={image.alt || defaultAlternative(index, numberOfImages)} width={imagesSize.width} height={imagesSize.height} />
 		</li>
 	);
 };

--- a/src/client/components/ui/Carousel/Slide.tsx
+++ b/src/client/components/ui/Carousel/Slide.tsx
@@ -20,6 +20,7 @@ interface SlideProps {
 	setDirection: (direction: Direction) => void
 	isAnimated: boolean
 	imagesSize: { width: number, height: number }
+	setError: (value: boolean) => void
 }
 
 export function defaultAlternative(index: number, numberOfImages: number) {
@@ -40,6 +41,7 @@ export const Slide = (props: SlideProps) => {
 		setDirection,
 		isAnimated,
 		imagesSize,
+		setError,
 	} = props;
 
 	const isCurrentSlide = useMemo(() => index === currentSlideIndex, [index, currentSlideIndex]);
@@ -68,7 +70,7 @@ export const Slide = (props: SlideProps) => {
 				{ [styles.transition]: isAnimated },
 			)}
 		>
-			<Image src={image.src} alt={image.alt || defaultAlternative(index, numberOfImages)} width={imagesSize.width} height={imagesSize.height} />
+			<Image src={image.src} onError={() => setError(true)} alt={image.alt || defaultAlternative(index, numberOfImages)} width={imagesSize.width} height={imagesSize.height} />
 		</li>
 	);
 };


### PR DESCRIPTION
Amélioration possible : Créer un wrapper sur <Image> pour ajouter une props type placeholderOnError qui va modifier directement src
```javascript
const handleImgError = (e) => {
  e.target.src = 'https://default-placehodler-image-path.svg';
};

<img
  src='http://4040.jpg'
  onError={handleImgError}
/>
```
https://stackoverflow.com/questions/29058211/react-jest-testing-error-event-on-img-tags

Sinon je n'ai pas réussi a tester le onError sur les images :/ A voir si arrivez, sinon c'est reviewable