### PR TITLE
chore: upgrade to Ubuntu 22 on Scalingo

### DIFF
--- a/terraform/front.tf
+++ b/terraform/front.tf
@@ -2,7 +2,7 @@ module "front_app" {
   source  = "scalingo-community/app/scalingo"
   version = "0.3.2"
 
-  stack = "scalingo-20"
+  stack = "scalingo-22"
 
   name = var.nom_de_l_application
 


### PR DESCRIPTION
La sortie d'Ubuntu 24.04 étant proche, c'est le moment d'upgrade à mon avis. Aucun impact attendu puisque Node 20 est bien compatible avec Ubuntu 22.