### PR TITLE
Revert "chore(deps): update getmeili/meilisearch docker tag to v1.7.6"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "6379:6379"
   meilisearch:
     container_name: "1j1s-meilisearch"
-    image: "getmeili/meilisearch:v1.7.5"
+    image: "getmeili/meilisearch:v1.7.4"
     environment:
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY:-masterKey}
       - MEILI_NO_ANALYTICS=${MEILI_NO_ANALYTICS:-true}


### PR DESCRIPTION
Reverts DNUM-SocialGouv/1j1s-front#2884

La version dispo dans le cloud est 1.7.4, pas 1.7.5