### PR TITLE
ci: build même avec Sentry en erreur

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -116,7 +116,16 @@ module.exports = isOnlineEnvironment
 			...moduleExports,
 			headers: async () => SECURITY_MODE_HEADERS,
 			sentry: sentryModuleExports,
-		}, undefined, sentryModuleExports)
+		}, {
+			errorHandler: (err, invokeErr, compilation) => {
+				if (err.message.includes('sentry')) {
+					compilation.warnings.push(`Erreur Sentry : ${err.message}`);
+				} else {
+					invokeErr();
+				}
+			},
+
+		}, sentryModuleExports)
 	: {
 		...moduleExports,
 		headers: async () => LOCAL_MODE_HEADERS,


### PR DESCRIPTION
Exemple d'un build en local qui se poursuit malgré l'erreur (et qui la log).
![image](https://github.com/DNUM-SocialGouv/1j1s-front/assets/128365508/e215cd96-03f1-4779-b9f3-79454f9a14d8)
