### PR TITLE
chore(alternance): ajuste les UTM des redirections LBA suite retour r…

### DIFF
--- a/config/redirects.js
+++ b/config/redirects.js
@@ -2,8 +2,9 @@ const LBA_CANDIDAT_BASE = process.env.NEXT_PUBLIC_LBA_LANDING_CANDIDAT_URL
 	|| 'https://labonnealternance.apprentissage.beta.gouv.fr/1jeune1solution';
 const LBA_RECRUTEUR_BASE = process.env.NEXT_PUBLIC_LBA_LANDING_RECRUTEUR_URL
 	|| 'https://labonnealternance.apprentissage.beta.gouv.fr/1jeune1solution-recruteurs';
-const LBA_CANDIDAT_URL = `${LBA_CANDIDAT_BASE}?utm_source=1jeune1solution`;
-const LBA_RECRUTEUR_URL = `${LBA_RECRUTEUR_BASE}?utm_source=1jeune1solution`;
+const UTM_COMMON = 'utm_source=1j1s&utm_medium=website';
+const LBA_CANDIDAT_URL = `${LBA_CANDIDAT_BASE}?${UTM_COMMON}&utm_campaign=landinglba1j1s`;
+const LBA_RECRUTEUR_URL = `${LBA_RECRUTEUR_BASE}?${UTM_COMMON}&utm_campaign=recruteurs_landinglba1j1s`;
 
 const ALL_MODE_REDIRECT = [
 	{

--- a/docs/docs/liens_lba/contexte.md
+++ b/docs/docs/liens_lba/contexte.md
@@ -1,3 +1,9 @@
+# Contexte et archives
+
+> **Mise à jour UTM (21 avril 2026)** : suite retour de LBA sur la recette, les UTM injectés côté destination sont désormais `utm_source=1j1s&utm_medium=website&utm_campaign=landinglba1j1s` (candidats) et `utm_source=1j1s&utm_medium=website&utm_campaign=recruteurs_landinglba1j1s` (recruteurs). Les mentions `utm_source=1jeune1solution` ci-dessous correspondent à la spec initiale (échange email et analyse technique du 13 au 14 avril). Source de vérité actuelle : `src/shared/lbaLandingUrls.ts` et `config/redirects.js`.
+
+## Archives : emails et analyse technique initiale
+
 De : GARTOUM, Houssine (DGEFP/SDFIMOD/MISI) <houssine.gartoum@emploi.gouv.fr>
 Envoyé : jeudi 9 avril 2026 15:29
 À : ADEBLE MENARD, Daisy (DNUM/SCN-SIM-ARS) <daisy.adeble-menard@sg.social.gouv.fr>

--- a/docs/docs/liens_lba/intention_tech.md
+++ b/docs/docs/liens_lba/intention_tech.md
@@ -2,7 +2,16 @@
 
 **Destinataires** : équipes LBA, DGEFP, hébergeur Scalingo
 **Objet** : présenter l'approche technique retenue côté 1J1S pour rediriger les parcours alternance vers les deux landing pages LBA, sans entrer dans le détail du code.
-**Version** : 1, 14 avril 2026
+**Version** : 2, 21 avril 2026 (v1 datée du 14 avril 2026, ajustement UTM post test recette)
+
+> **Mise à jour UTM (21 avril 2026)** : suite retour de LBA, les UTM hardcodés côté destination sont désormais :
+>
+> * Candidats : `utm_source=1j1s&utm_medium=website&utm_campaign=landinglba1j1s`
+> * Recruteurs : `utm_source=1j1s&utm_medium=website&utm_campaign=recruteurs_landinglba1j1s`
+>
+> Par rapport à la v1 (`utm_source=1jeune1solution` seul) : la valeur `utm_source` change, et deux paramètres `utm_medium` + `utm_campaign` sont ajoutés. Conséquence notable : les `utm_campaign` et `utm_medium` présents dans une URL source tierce sont désormais écrasés par les valeurs hardcodées (comportement standard des redirects Next.js, déjà le cas pour `utm_source` en v1). Compromis accepté pour permettre à LBA de mesurer un canal « landing 1J1S » unifié.
+>
+> L'URL de base reste configurable par environnement via `NEXT_PUBLIC_LBA_LANDING_CANDIDAT_URL` et `NEXT_PUBLIC_LBA_LANDING_RECRUTEUR_URL` (recette LBA vs prod LBA). Les UTM sont systématiquement appendés par le code, impossible à omettre en configuration.
 
 ## 1. Objectif
 

--- a/docs/docs/liens_lba/ticket.md
+++ b/docs/docs/liens_lba/ticket.md
@@ -1,5 +1,12 @@
 # Rediriger les parcours alternance 1J1S vers les landing pages LBA dédiées
 
+> **Mise à jour post test recette (21 avril 2026)** : suite retour de LBA, les UTM injectés sur les redirections ont été ajustés. Les valeurs effectives produites par le code sont désormais :
+>
+> * Candidats : `utm_source=1j1s&utm_medium=website&utm_campaign=landinglba1j1s`
+> * Recruteurs : `utm_source=1j1s&utm_medium=website&utm_campaign=recruteurs_landinglba1j1s`
+>
+> Les mentions `utm_source=1jeune1solution` dans le corps de ce ticket correspondent à la spec initiale, pas à l'état courant.
+
 **Type** : User story (avec volet enabler de nettoyage)
 **Priorité** : P1
 **Échéance** : semaine du 20 avril 2026 au plus tard (campagne grand public alternance en mai 2026)

--- a/src/pages/plan-du-site/index.page.test.tsx
+++ b/src/pages/plan-du-site/index.page.test.tsx
@@ -21,7 +21,7 @@ describe('Plan du site', () => {
 		${'Emplois'}                                              | ${'/emplois'}
 		${'Stages d’études'}                                      | ${'/stages'}
 		${'Stages de 3e et 2de'}                                	| ${'/stages-3e-et-2de'}
-		${'Contrats d’alternance'}                                | ${'https://labonnealternance.apprentissage.beta.gouv.fr/1jeune1solution?utm_source=1jeune1solution'}
+		${'Contrats d’alternance'}                                | ${'https://labonnealternance.apprentissage.beta.gouv.fr/1jeune1solution?utm_source=1j1s&utm_medium=website&utm_campaign=landinglba1j1s'}
 		${'Jobs d‘été'}                                           | ${'/jobs-ete'}
 		${'Jobs étudiants'}                                       | ${'/jobs-etudiants'}
 		${'Emplois en Europe'}                                    | ${'/emplois-europe'}
@@ -31,7 +31,7 @@ describe('Plan du site', () => {
 		${'Formations en apprentissage'}                          | ${'/formations/apprentissage'}
 		${'Découvrir les métiers'}                                | ${'/decouvrir-les-metiers'}
 		${'Participer à des évènements'}                          | ${'/evenements'}
-		${'Découvrir et trouver sa voie avec l’apprentissage'}    | ${'https://labonnealternance.apprentissage.beta.gouv.fr/1jeune1solution?utm_source=1jeune1solution'}
+		${'Découvrir et trouver sa voie avec l’apprentissage'}    | ${'https://labonnealternance.apprentissage.beta.gouv.fr/1jeune1solution?utm_source=1j1s&utm_medium=website&utm_campaign=landinglba1j1s'}
 		${'Découvrir les services jeunes liés aux formations et à l’orientation'}   | ${'/services-jeunes?filtre=orienterFormer'}
 		
 		${'Bénévolat'}                                            | ${'/benevolat'}
@@ -60,7 +60,7 @@ describe('Plan du site', () => {
 		${'Je deviens mentor'}                                    | ${'/je-deviens-mentor'}
 		${'Je propose des immersions'}                            | ${'/immersions'}
 		${'Je forme les jeunes grâce à l‘emploi'}                 | ${'/je-recrute-afpr-poei'}
-		${'Je recrute un apprenti'} 							                | ${'https://labonnealternance.apprentissage.beta.gouv.fr/1jeune1solution-recruteurs?utm_source=1jeune1solution'}
+		${'Je recrute un apprenti'} 							                | ${'https://labonnealternance.apprentissage.beta.gouv.fr/1jeune1solution-recruteurs?utm_source=1j1s&utm_medium=website&utm_campaign=recruteurs_landinglba1j1s'}
 		${'Découvrir les mesures employeurs'}                     | ${'/mesures-employeurs'}
 		${'Accéder à mon espace'}                                 | ${'/mon-espace'}
 		

--- a/src/shared/lbaLandingUrls.test.ts
+++ b/src/shared/lbaLandingUrls.test.ts
@@ -1,0 +1,24 @@
+import { LBA_CANDIDAT_URL, LBA_RECRUTEUR_URL } from '~/shared/lbaLandingUrls';
+
+describe('lbaLandingUrls', () => {
+	it('LBA_CANDIDAT_URL cible la landing candidats avec les 3 UTM attendus', () => {
+		expect(LBA_CANDIDAT_URL).toContain('/1jeune1solution?');
+		expect(LBA_CANDIDAT_URL).not.toContain('/1jeune1solution-recruteurs');
+		expect(LBA_CANDIDAT_URL).toContain('utm_source=1j1s');
+		expect(LBA_CANDIDAT_URL).toContain('utm_medium=website');
+		expect(LBA_CANDIDAT_URL).toContain('utm_campaign=landinglba1j1s');
+		expect(LBA_CANDIDAT_URL).not.toContain('utm_campaign=recruteurs_');
+	});
+
+	it('LBA_RECRUTEUR_URL cible la landing recruteurs avec les 3 UTM attendus', () => {
+		expect(LBA_RECRUTEUR_URL).toContain('/1jeune1solution-recruteurs?');
+		expect(LBA_RECRUTEUR_URL).toContain('utm_source=1j1s');
+		expect(LBA_RECRUTEUR_URL).toContain('utm_medium=website');
+		expect(LBA_RECRUTEUR_URL).toContain('utm_campaign=recruteurs_landinglba1j1s');
+	});
+
+	it('les deux URLs sont syntaxiquement valides', () => {
+		expect(() => new URL(LBA_CANDIDAT_URL)).not.toThrow();
+		expect(() => new URL(LBA_RECRUTEUR_URL)).not.toThrow();
+	});
+});

--- a/src/shared/lbaLandingUrls.ts
+++ b/src/shared/lbaLandingUrls.ts
@@ -3,5 +3,6 @@ const LBA_CANDIDAT_BASE = process.env.NEXT_PUBLIC_LBA_LANDING_CANDIDAT_URL
 const LBA_RECRUTEUR_BASE = process.env.NEXT_PUBLIC_LBA_LANDING_RECRUTEUR_URL
 	|| 'https://labonnealternance.apprentissage.beta.gouv.fr/1jeune1solution-recruteurs';
 
-export const LBA_CANDIDAT_URL = `${LBA_CANDIDAT_BASE}?utm_source=1jeune1solution`;
-export const LBA_RECRUTEUR_URL = `${LBA_RECRUTEUR_BASE}?utm_source=1jeune1solution`;
+const UTM_COMMON = 'utm_source=1j1s&utm_medium=website';
+export const LBA_CANDIDAT_URL = `${LBA_CANDIDAT_BASE}?${UTM_COMMON}&utm_campaign=landinglba1j1s`;
+export const LBA_RECRUTEUR_URL = `${LBA_RECRUTEUR_BASE}?${UTM_COMMON}&utm_campaign=recruteurs_landinglba1j1s`;


### PR DESCRIPTION
…ecette

Suite test recette par l'équipe LBA, les UTM hardcodés côté destination sont révisés par rapport à la v1 signée dans le cahier initial.

Delta par rapport au commit précédent (9bcfc45db) :
  Avant : utm_source=1jeune1solution (un seul param, valeur historique)
  Après : utm_source=1j1s&utm_medium=website&utm_campaign=<differencie>
    candidats:  utm_campaign=landinglba1j1s
    recruteurs: utm_campaign=recruteurs_landinglba1j1s

Conséquence : les paramètres utm_medium et utm_campaign éventuellement présents sur l'URL source sont désormais écrasés par les valeurs destination (comportement Next.js redirects). C'était déjà le cas pour utm_source en v1, étendu aux 2 nouveaux paramètres. Compromis accepté, permet à LBA d'unifier la mesure du canal landing 1J1S dans Plausible et Matomo.

Changements :
  src/shared/lbaLandingUrls.ts : factorisation UTM_COMMON et concaténation
  config/redirects.js : duplication de la logique (CJS de next.config)
  src/shared/lbaLandingUrls.test.ts : nouveau, verrouille les valeurs attendues
    et prévient une inversion candidats/recruteurs future
  src/pages/plan-du-site/index.page.test.tsx : 3 assertions alignées
  docs/docs/liens_lba/*.md : addendum en tête signalant la révision UTM

Ref TICKET-59 Notion.