### PR TITLE
fix(liens externes): remplace plusieurs URL externes mortes

### DIFF
--- a/src/client/components/features/Entreprendre/Réseau/EntreprendreReseau.tsx
+++ b/src/client/components/features/Entreprendre/Réseau/EntreprendreReseau.tsx
@@ -277,7 +277,7 @@ export const RÉSEAU_FINANCEMENT: EntreprendreRéseauProps[] = [{
 export const RÉSEAU_ÉCONOMIE_SOCIALE_ET_SOLIDAIRE: EntreprendreRéseauProps[] = [{
 	entreprise: {
 		description: 'Pour les jeunes de moins de 30 ans, Live for Good propose un parcours de formations collectif et un coaching individualisé pour structurer et faire décoller son projet entrepreneurial.',
-		lien: 'https://candidater.live-for-good.org/',
+		lien: 'https://www.live-for-good.org/',
 		logo: '/images/entreprendre/live_for_good.png',
 		nom: 'Live for Good',
 		tagline: '6 mois pour accélérer votre projet à impact positif.',

--- a/src/client/components/layouts/Header/Banner/EnqueteSatisfaction/EnqueteSatisfactionBanner.tsx
+++ b/src/client/components/layouts/Header/Banner/EnqueteSatisfaction/EnqueteSatisfactionBanner.tsx
@@ -4,13 +4,13 @@ import { Link } from '~/client/components/ui/Link/Link';
 
 import styles from './EnqueteSatisfactionBanner.module.scss';
 
-const ENQUETE_SATISFACTION_URL = 'https://jedonnemonavis.numerique.gouv.fr/Demarches/4085?button=4514';
+const ENQUETE_SATISFACTION_URL = 'https://tally.so/r/J9ePWJ';
 
 export function EnqueteSatisfactionBanner() {
 	return (
 		<div className={styles.enqueteBanner}>
 			<Link href={ENQUETE_SATISFACTION_URL} className={styles.enqueteLink} appearance={'asQuaternaryButton'}>
-			Vous souhaitez aider 1jeune1solution à s&apos;améliorer ? Donnez votre avis en moins de 2 minutes
+			Aidez nous à construire l&apos;application mobile de vos rêves 📲
 				<Link.Icon />
 			</Link>
 		</div>

--- a/src/client/components/layouts/Header/Header.test.tsx
+++ b/src/client/components/layouts/Header/Header.test.tsx
@@ -235,9 +235,9 @@ describe('Header', () => {
 				render(<Header />);
 
 				// THEN
-				const lienEnquete = screen.getByRole('link', { name: "Vous souhaitez aider 1jeune1solution à s'améliorer ? Donnez votre avis en moins de 2 minutes - nouvelle fenêtre" });
+				const lienEnquete = screen.getByRole('link', { name: "Aidez nous à construire l'application mobile de vos rêves 📲 - nouvelle fenêtre" });
 				expect(lienEnquete).toBeVisible();
-				expect(lienEnquete).toHaveAttribute('href', 'https://jedonnemonavis.numerique.gouv.fr/Demarches/4085?button=4514');
+				expect(lienEnquete).toHaveAttribute('href', 'https://tally.so/r/J9ePWJ');
 			});
 
 
@@ -250,7 +250,7 @@ describe('Header', () => {
 				render(<Header />);
 
 				// THEN
-				const lienEnquete = screen.queryByRole('link', { name: "Vous souhaitez aider 1jeune1solution à s'améliorer ? Donnez votre avis en moins de 2 minutes" });
+				const lienEnquete = screen.queryByRole('link', { name: "Aidez nous à construire l'application mobile de vos rêves 📲" });
 				expect(lienEnquete).not.toBeInTheDocument();
 			});
 		});

--- a/src/pages/creer-mon-cv/index.page.tsx
+++ b/src/pages/creer-mon-cv/index.page.tsx
@@ -18,7 +18,7 @@ export default function FormationPage() {
 					titlePrimaryText="Je crée un CV personnalisé qui valorise mes compétences "
 					titleSecondaryText="et s’adapte à chaque annonce"
 					content={heroCVContent()}
-					buttonHref="https://plateforme.diagoriente.beta.gouv.fr"
+					buttonHref="https://diagoriente.fr/"
 					buttonLabel="Créer mon CV"
 					imgSrc="/images/créer-son-cv.webp" />
 			</main>

--- a/src/pages/evenements/index.page.tsx
+++ b/src/pages/evenements/index.page.tsx
@@ -35,7 +35,7 @@ export default function PageEvenements() {
 								buttonLabel='Trouver un événement France Travail'
 								buttonLabelSecondary='Trouver un événement ma Mission Locale'
 								buttonHref='https://mesevenementsemploi.francetravail.fr/mes-evenements-emploi/evenements'
-								buttonHrefSecondary='https://40-ans.unml.info/le-programme'
+								buttonHrefSecondary='https://www.unml.info/actualites/nos-actualites/?category=154&post_tag='
 								imgSrc='/images/évènements.webp' />
 						</main>
 					</>


### PR DESCRIPTION
## Résumé

Remplacement de liens externes morts ou obsolètes signalés en production.

* **Page « Créer mon CV »** : bouton principal `plateforme.diagoriente.beta.gouv.fr` (404) remplacé par `https://diagoriente.fr/`.
* **Bandeau enquête satisfaction du header** : wording mis à jour vers « Aidez nous à construire l'application mobile de vos rêves 📲 » et redirection vers `https://tally.so/r/J9ePWJ` au lieu de `jedonnemonavis.numerique.gouv.fr/Demarches/4085`.
* **Page « Évènements »** : bouton secondaire `40-ans.unml.info/le-programme` (programme événementiel terminé) remplacé par la liste des actualités UNML `https://www.unml.info/actualites/nos-actualites/?category=154&post_tag=`.
* **Annuaire Entreprendre, section ESS** : carte « Live for Good » pointe désormais vers `https://www.live-for-good.org/` plutôt que la page de candidature `candidater.live-for-good.org`.
* Tests du `Header` réalignés sur le nouveau wording et la nouvelle URL.

## Points à valider en review

* `post_tag=` vide sur l'URL UNML : à confirmer côté UNML que le filtre tombe bien sur `category=154` seul.
* `JeDonneMonAvis.tsx` (formulaire `Demarches/3639`) reste sur l'ancien fournisseur, hors périmètre.

## Test plan

* [ ] `npm run lint` passe
* [ ] `npm run check-types` passe
* [ ] `npm test` passe (notamment `Header.test.tsx`)
* [ ] Vérifier visuellement `/creer-mon-cv` → clic sur « Créer mon CV » ouvre `diagoriente.fr`
* [ ] Vérifier le bandeau header (feature flag `NEXT_PUBLIC_ENQUETE_SATISFACTION_FEATURE=1`) → nouveau wording + redirection Tally
* [ ] Vérifier `/evenements` (route legacy, hors flag `NEXT_PUBLIC_RECHERCHE_EVENEMENT_FEATURE`) → bouton secondaire UNML pointe sur la liste d'actualités
* [ ] Vérifier `/creer-entreprise` (ou page hébergeant `RéseauÉconomieSocialeEtSolidaireList`) → carte Live for Good redirige vers la home