### PR TITLE
fix(cms): retourne un 404 au lieu d'un 500 quand le slug est absent d…

### DIFF
--- a/src/server/cms/infra/repositories/strapi.service.test.ts
+++ b/src/server/cms/infra/repositories/strapi.service.test.ts
@@ -160,24 +160,16 @@ describe('strapiService', () => {
 		});
 
 		describe('lorsque l‘appel à Strapi est en succès', () => {
-			it('lorsqu‘il n‘y a pas de résultat, appelle le service et gestion d‘erreur et relais la failure associée', async () => {
-				const ressource = 'ressource';
-				const expectedFailureFromErrorManagementService = createFailure(ErreurMetier.SERVICE_INDISPONIBLE);
+			it('lorsqu‘il n‘y a pas de résultat, retourne une failure CONTENU_INDISPONIBLE sans solliciter la gestion d‘erreur', async () => {
 				const httpClientService = aPublicHttpClientService();
 				const errorManagementService = anErrorManagementService();
 				vi.spyOn(httpClientService, 'get').mockResolvedValue(anAxiosResponse(aStrapiCollectionType([])));
-				vi.spyOn(errorManagementService, 'handleFailureError').mockReturnValue(expectedFailureFromErrorManagementService);
 				const strapiService = new StrapiService(httpClientService, anAuthenticatedHttpClientService(), errorManagementService);
 
-				const result = await strapiService.getFirstFromCollectionType(ressource, 'query');
+				const result = await strapiService.getFirstFromCollectionType('ressource', 'query');
 
-				expect(errorManagementService.handleFailureError).toHaveBeenCalledTimes(1);
-				expect(errorManagementService.handleFailureError).toHaveBeenCalledWith(new Error('pas de résultat'), aLogInformation({
-					apiSource: 'API Strapi',
-					contexte: 'get first from collection type strapi',
-					message: `Erreur inconnue - Aucune donnée dans le résultat associé à la ressource ${ressource}`,
-				}));
-				expect(result).toEqual(expectedFailureFromErrorManagementService);
+				expect(errorManagementService.handleFailureError).not.toHaveBeenCalled();
+				expect(result).toEqual(createFailure(ErreurMetier.CONTENU_INDISPONIBLE));
 			});
 
 			it('lorsqu‘il y a plusieurs résultats, renvoie un succès avec le premier résultat de la liste', async () => {

--- a/src/server/cms/infra/repositories/strapi.service.ts
+++ b/src/server/cms/infra/repositories/strapi.service.ts
@@ -1,6 +1,7 @@
 import { CmsService } from '~/server/cms/domain/cmsService';
 import { StrapiCollectionType, StrapiSingleType } from '~/server/cms/infra/repositories/strapi.response';
-import { createSuccess, Either } from '~/server/errors/either';
+import { createFailure, createSuccess, Either } from '~/server/errors/either';
+import { ErreurMetier } from '~/server/errors/erreurMetier.types';
 import { ErrorManagementService, Severity } from '~/server/services/error/errorManagement.service';
 import { AuthenticatedHttpClientService } from '~/server/services/http/authenticatedHttpClient.service';
 import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
@@ -64,11 +65,7 @@ export class StrapiService implements CmsService {
 			const result = await this.getPaginatedCollectionType<Collection>(resource, query, firstPage);
 			const data = result.data;
 			if (data.length === 0) {
-				return this.errorManagementService.handleFailureError(new Error('pas de résultat'), {
-					apiSource: 'API Strapi',
-					contexte: 'get first from collection type strapi',
-					message: `Erreur inconnue - Aucune donnée dans le résultat associé à la ressource ${resource}`,
-				});			
+				return createFailure(ErreurMetier.CONTENU_INDISPONIBLE);
 			}
 			return createSuccess(data[0].attributes);
 		} catch (error) {


### PR DESCRIPTION
…u CMS

Un slug absent dans Strapi n'est pas une erreur technique. Avant ce correctif, getFirstFromCollectionType passait par handleFailureError, ce qui, via l'override createFailureForInternalError du StrapiErrorManagementService, finissait en SERVICE_INDISPONIBLE puis en 500 sur la page consultée (page "Service Indisponible" du front).

On retourne désormais directement CONTENU_INDISPONIBLE, traduit en notFound: true (404) par handleGetServerSidePropsError. Bénéficie à toutes les ressources qui résolvent un slug via le CMS : stages, logements, articles, faq, fiche-metier, formations-initiales.