### PR TITLE
fix: réduit la charge sur le CMS (cache du sitemap + concurrence bornée)

### DIFF
--- a/src/pages/api/sitemap/index.controller.ts
+++ b/src/pages/api/sitemap/index.controller.ts
@@ -1,12 +1,37 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
 import { ErrorHttpResponse } from '~/pages/api/utils/response/response.type';
+import { créerCacheSitemap } from '~/server/sitemap/infra/sitemapCache';
 import { dependencies } from '~/server/start';
 
-export default async function générerSitemapXml(req: NextApiRequest, res: NextApiResponse<void | ErrorHttpResponse>) {
-	const sitemap = await dependencies.sitemapDependencies.générerSitemapUseCase.handle();
+// Durée de fraîcheur du sitemap en cache. 6h par défaut : un sitemap n'est qu'un indice de
+// découverte pour les moteurs, il n'a pas besoin d'être régénéré à chaque requête (c'est
+// justement ce qui saturait le CMS). Pilotable par env sans redéployer le code.
+const SITEMAP_TTL_S = Number(process.env.SITEMAP_CACHE_TTL_S) || 21600;
 
-	res.setHeader('Content-Type', 'text/xml');
-	res.write(sitemap);
-	res.end();
+// Instancié UNE seule fois au niveau module, pour que le cache survive entre les requêtes
+// (le module d'une route API Next est chargé une fois par process). Le générateur est passé
+// en closure, donc résolu paresseusement au premier appel (pas de dépendance au moment du chargement).
+const obtenirSitemap = créerCacheSitemap(
+	() => dependencies.sitemapDependencies.générerSitemapUseCase.handle(),
+	{ ttlMs: SITEMAP_TTL_S * 1000, seuilMinUrls: 50 },
+);
+
+export default async function générerSitemapXml(req: NextApiRequest, res: NextApiResponse<void | ErrorHttpResponse>) {
+	try {
+		const sitemap = await obtenirSitemap();
+
+		res.setHeader('Content-Type', 'text/xml; charset=utf-8');
+		// Indice de cache pour un éventuel CDN en amont (sans effet tant qu'aucune règle CDN ne
+		// force la mise en cache de cette route ; le cache in-process reste le mécanisme actif).
+		res.setHeader('Cache-Control', `public, s-maxage=${SITEMAP_TTL_S}, stale-while-revalidate=86400`);
+		res.setHeader('X-Content-Type-Options', 'nosniff');
+		res.write(sitemap);
+		res.end();
+	} catch {
+		// Génération à froid en échec (CMS indisponible et aucun XML précédent à resservir) :
+		// on renvoie 503 + Retry-After plutôt qu'un sitemap vide, qui ferait déréférencer les URLs.
+		res.setHeader('Retry-After', '60');
+		res.status(503).end();
+	}
 }

--- a/src/server/cms/infra/repositories/strapi.service.test.ts
+++ b/src/server/cms/infra/repositories/strapi.service.test.ts
@@ -1,6 +1,6 @@
 import { aStrapiCollectionType, aStrapiSingleType } from '~/server/cms/infra/repositories/strapi.fixture';
-import { StrapiService } from '~/server/cms/infra/repositories/strapi.service';
-import { createFailure, createSuccess } from '~/server/errors/either';
+import { NOMBRE_MAX_REQUETES_PARALLELES_CMS, StrapiService } from '~/server/cms/infra/repositories/strapi.service';
+import { createFailure, createSuccess, isSuccess } from '~/server/errors/either';
 import { ErreurMetier } from '~/server/errors/erreurMetier.types';
 import { aLogInformation, anErrorManagementService } from '~/server/services/error/errorManagement.fixture';
 import { Severity } from '~/server/services/error/errorManagement.service';
@@ -121,6 +121,35 @@ describe('strapiService', () => {
 				expect(httpClientService.get).toHaveBeenNthCalledWith(3, `ressource?query&pagination[pageSize]=${MAX_PAGINATION_SIZE}&pagination[page]=3`);
 				expect(httpClientService.get).toHaveBeenNthCalledWith(4, `ressource?query&pagination[pageSize]=${MAX_PAGINATION_SIZE}&pagination[page]=4`);
 				expect(result).toEqual(createSuccess([...dataPremierePage, ...dataDeuxiemePage, ...dataTroisiemePage, ...dataQuatriemePage]));
+			});
+
+			it('plafonne le nombre de requêtes envoyées simultanément au CMS pour ne pas le saturer', async () => {
+				// Test de non-régression de l'incident prod du 24/06/2026 : on simule une grosse
+				// collection (bien plus de pages que le plafond) et on mesure le nombre maximal de
+				// requêtes en vol au même instant. Il ne doit jamais dépasser le plafond, sinon on
+				// retombe sur la rafale qui saturait puis crashait le conteneur unique du CMS.
+				const nombreTotalDePages = NOMBRE_MAX_REQUETES_PARALLELES_CMS * 2 + 1;
+				const httpClientService = aPublicHttpClientService();
+				let requetesEnCours = 0;
+				let maxRequetesSimultanees = 0;
+				vi.spyOn(httpClientService, 'get').mockImplementation((endpoint) => {
+					requetesEnCours++;
+					maxRequetesSimultanees = Math.max(maxRequetesSimultanees, requetesEnCours);
+					// La requête ne se résout qu'au microtask suivant : tant qu'un lot n'est pas
+					// résolu, ses requêtes restent comptées comme « en cours » simultanément.
+					const numeroPage = Number(endpoint.split('pagination[page]=')[1] ?? '1');
+					return Promise.resolve().then(() => {
+						requetesEnCours--;
+						return anAxiosResponse(aStrapiCollectionType([{ test: `page${numeroPage}` }], { page: numeroPage, pageCount: nombreTotalDePages }));
+					});
+				});
+				const strapiService = new StrapiService(httpClientService, anAuthenticatedHttpClientService(), anErrorManagementService());
+
+				const result = await strapiService.getCollectionType('ressource', 'query');
+
+				expect(httpClientService.get).toHaveBeenCalledTimes(nombreTotalDePages);
+				expect(maxRequetesSimultanees).toBeLessThanOrEqual(NOMBRE_MAX_REQUETES_PARALLELES_CMS);
+				expect(isSuccess(result)).toBe(true);
 			});
 		});
 

--- a/src/server/cms/infra/repositories/strapi.service.ts
+++ b/src/server/cms/infra/repositories/strapi.service.ts
@@ -8,6 +8,20 @@ import { PublicHttpClientService } from '~/server/services/http/publicHttpClient
 
 const MAX_PAGINATION_SIZE = '100';
 
+// Nombre maximum de requêtes lancées EN PARALLÈLE vers le CMS lors de la récupération
+// d'une collection paginée.
+//
+// Pourquoi ce plafond existe-t-il ?
+// Certaines collections (ex. annonces-de-logement : ~850 pages) étaient récupérées en
+// lançant TOUTES les pages d'un coup via un unique Promise.all. Le CMS Strapi tourne sur
+// un conteneur unique : ces rafales (pics mesurés à ~430 requêtes/seconde) saturaient son
+// pool de connexions à la base et son event loop, provoquant des réponses 503 puis le
+// crash et le redémarrage automatique du conteneur en production (incident du 24/06/2026,
+// génération du sitemap). On borne donc le nombre de requêtes simultanées pour lisser la
+// charge. La valeur est volontairement basse et alignée sur la taille du pool de
+// connexions configuré côté CMS, afin de ne jamais le saturer.
+export const NOMBRE_MAX_REQUETES_PARALLELES_CMS = 5;
+
 export class StrapiService implements CmsService {
 	constructor(
 		private httpClientService: PublicHttpClientService,
@@ -39,12 +53,24 @@ export class StrapiService implements CmsService {
 
 			const hasSeveralPages = pageCount > page;
 			if (hasSeveralPages) {
-				const promiseList = [];
+				// La page 1 a déjà été chargée ci-dessus ; on liste les pages restantes à récupérer.
+				const pagesRestantes: number[] = [];
 				for (let currentPage = page + 1; currentPage <= pageCount; currentPage++) {
-					promiseList.push(this.getPaginatedCollectionType<Collection>(resource, query, currentPage));
+					pagesRestantes.push(currentPage);
 				}
-				const resultList = await Promise.all(promiseList);
-				dataResponseList.push(...resultList.flatMap((result) => result.data));
+
+				// On récupère ces pages par LOTS successifs plutôt que toutes en même temps :
+				// au plus NOMBRE_MAX_REQUETES_PARALLELES_CMS requêtes sont en vol simultanément,
+				// et le lot suivant ne démarre qu'une fois le précédent entièrement résolu (await).
+				// Le résultat final est identique à l'ancien code (mêmes pages, même ordre), mais
+				// la charge envoyée au CMS est lissée au lieu d'arriver en une seule rafale.
+				for (let debutLot = 0; debutLot < pagesRestantes.length; debutLot += NOMBRE_MAX_REQUETES_PARALLELES_CMS) {
+					const lotDePages = pagesRestantes.slice(debutLot, debutLot + NOMBRE_MAX_REQUETES_PARALLELES_CMS);
+					const resultatsDuLot = await Promise.all(
+						lotDePages.map((numeroPage) => this.getPaginatedCollectionType<Collection>(resource, query, numeroPage)),
+					);
+					dataResponseList.push(...resultatsDuLot.flatMap((resultat) => resultat.data));
+				}
 			}
 
 			const collections = dataResponseList.map((data) => data.attributes);

--- a/src/server/engagement/infra/repositories/apiEngagement.repository.test.ts
+++ b/src/server/engagement/infra/repositories/apiEngagement.repository.test.ts
@@ -165,6 +165,18 @@ describe('ApiEngagementRepository', () => {
 			});
 		});
 
+		describe('quand l’id n’a pas le format d’un identifiant de mission (ObjectId)', () => {
+			it('retourne une erreur de contenu indisponible sans appeler l’api engagement', async () => {
+				vi.spyOn(httpClientService, 'get');
+				const identifiantAuMauvaisFormat = 'b0d143f4-4b75-49be-bfab-cbf4d5443368';
+
+				const { errorType } = await apiEngagementRepository.getMissionEngagement(identifiantAuMauvaisFormat) as Failure;
+
+				expect(httpClientService.get).not.toHaveBeenCalled();
+				expect(errorType).toEqual(ErreurMetier.CONTENU_INDISPONIBLE);
+			});
+		});
+
 		describe('quand l’api engagement répond avec une erreur', () => {
 			it('log les informations de l’erreur et retourne une erreur métier associée', async () => {
 				const httpError = anHttpError(500);

--- a/src/server/engagement/infra/repositories/apiEngagement.repository.ts
+++ b/src/server/engagement/infra/repositories/apiEngagement.repository.ts
@@ -12,17 +12,26 @@ import {
 	RésultatsMissionEngagementResponse,
 	RésultatsRechercheMissionEngagementResponse,
 } from '~/server/engagement/infra/repositories/apiEngagement.response';
-import { createSuccess, Either } from '~/server/errors/either';
+import { createFailure, createSuccess, Either } from '~/server/errors/either';
+import { ErreurMetier } from '~/server/errors/erreurMetier.types';
 import { ErrorManagementService } from '~/server/services/error/errorManagement.service';
 import { PublicHttpClientService } from '~/server/services/http/publicHttpClient.service';
 
 const JE_VEUX_AIDER_PUBLISHER_ID = '5f5931496c7ea514150a818f';
 const SERVICE_CIVIQUE_PUBLISHER_ID = '5f99dbe75eb1ad767733b206';
 
+// L’API Engagement identifie ses missions par un ObjectId MongoDB (24 caractères hexadécimaux).
+// Tout id d’un autre format (ex : UUID de vieilles URL indexées) ne peut correspondre à aucune
+// mission : on court-circuite pour ne pas polluer l’API partenaire avec des requêtes vouées au 404.
+const FORMAT_ID_MISSION_ENGAGEMENT = /^[a-f\d]{24}$/i;
+
 export class ApiEngagementRepository implements EngagementRepository {
 	constructor(private readonly httpClientService: PublicHttpClientService, private readonly errorManagementService: ErrorManagementService) {}
 
 	async getMissionEngagement(id: MissionId): Promise<Either<Mission>> {
+		if (!FORMAT_ID_MISSION_ENGAGEMENT.test(id)) {
+			return createFailure(ErreurMetier.CONTENU_INDISPONIBLE);
+		}
 		try {
 			const response = await this.httpClientService.get<RésultatsMissionEngagementResponse>(
 				`mission/${id}`,

--- a/src/server/sitemap/infra/sitemapCache.test.ts
+++ b/src/server/sitemap/infra/sitemapCache.test.ts
@@ -1,0 +1,64 @@
+import { créerCacheSitemap } from '~/server/sitemap/infra/sitemapCache';
+
+function xmlAvecUrls(nombre: number): string {
+	return `<urlset>${'<url><loc>https://exemple/x</loc></url>'.repeat(nombre)}</urlset>`;
+}
+
+describe('créerCacheSitemap', () => {
+	it('sert la valeur en cache sans rappeler le générateur tant qu\'elle est fraîche', async () => {
+		const générer = vi.fn().mockResolvedValue(xmlAvecUrls(100));
+		const obtenir = créerCacheSitemap(générer, { ttlMs: 10_000, seuilMinUrls: 10 });
+
+		await obtenir();
+		await obtenir();
+
+		expect(générer).toHaveBeenCalledTimes(1);
+	});
+
+	it('single-flight : des appels concurrents ne déclenchent qu\'une seule génération', async () => {
+		let résoudre: (xml: string) => void = () => {};
+		const générer = vi.fn().mockImplementation(() => new Promise<string>((r) => { résoudre = r; }));
+		const obtenir = créerCacheSitemap(générer, { ttlMs: 10_000, seuilMinUrls: 10 });
+
+		const appels = Promise.all([obtenir(), obtenir(), obtenir()]);
+		résoudre(xmlAvecUrls(100));
+		const résultats = await appels;
+
+		expect(générer).toHaveBeenCalledTimes(1);
+		expect(résultats).toEqual([xmlAvecUrls(100), xmlAvecUrls(100), xmlAvecUrls(100)]);
+	});
+
+	it('ne met pas en cache une réponse sous le seuil (sitemap tronqué), donc régénère', async () => {
+		const générer = vi.fn().mockResolvedValue(xmlAvecUrls(3));
+		const obtenir = créerCacheSitemap(générer, { ttlMs: 10_000, seuilMinUrls: 10 });
+
+		await obtenir();
+		await obtenir();
+
+		expect(générer).toHaveBeenCalledTimes(2);
+	});
+
+	it('ne met pas une erreur en cache et la propage si aucun bon XML précédent', async () => {
+		const générer = vi.fn().mockRejectedValue(new Error('CMS indisponible'));
+		const obtenir = créerCacheSitemap(générer, { ttlMs: 10_000, seuilMinUrls: 10 });
+
+		await expect(obtenir()).rejects.toThrow('CMS indisponible');
+		await expect(obtenir()).rejects.toThrow('CMS indisponible');
+		expect(générer).toHaveBeenCalledTimes(2); // pas de « poison » : chaque appel réessaie
+	});
+
+	it('en cas d\'erreur, ressert le dernier bon sitemap si disponible (stale-on-error)', async () => {
+		const générer = vi.fn()
+			.mockResolvedValueOnce(xmlAvecUrls(100))
+			.mockRejectedValueOnce(new Error('CMS indisponible'));
+		// ttl négatif : l'entrée est considérée périmée immédiatement, forçant une régénération au 2e appel.
+		const obtenir = créerCacheSitemap(générer, { ttlMs: -1, seuilMinUrls: 10 });
+
+		const premier = await obtenir();
+		const second = await obtenir();
+
+		expect(premier).toEqual(xmlAvecUrls(100));
+		expect(second).toEqual(xmlAvecUrls(100));
+		expect(générer).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/server/sitemap/infra/sitemapCache.ts
+++ b/src/server/sitemap/infra/sitemapCache.ts
@@ -1,0 +1,60 @@
+interface OptionsCacheSitemap {
+	ttlMs: number;
+	seuilMinUrls: number;
+}
+
+// Cache en mémoire du sitemap avec verrou « single-flight ».
+//
+// Contexte : la route /api/sitemap régénérait les 5 collections du CMS à CHAQUE requête,
+// sans aucun cache. Couplé au fan-out de pagination côté client Strapi, cela envoyait des
+// centaines de requêtes quasi simultanées vers le CMS (conteneur unique) et le saturait
+// jusqu'au crash en production (incidents du 24/06 et du 05/07 2026).
+//
+// Deux protections complémentaires ici :
+//  1. memoize TTL : tant qu'une réponse est fraîche, elle est servie sans rappeler le CMS.
+//  2. single-flight : si une régénération est déjà en cours, les requêtes concurrentes
+//     attendent la MÊME promesse au lieu d'en déclencher chacune une (c'est ce qui évite
+//     la rafale, y compris au démarrage à froid après un redémarrage du conteneur).
+//
+// Garde-fous (le cache ne doit jamais rendre la situation pire qu'avant) :
+//  - on ne met en cache QUE les réponses valides (au moins `seuilMinUrls` URLs), jamais un
+//    sitemap tronqué qui figerait une réponse incomplète pendant tout le TTL ;
+//  - on ne met JAMAIS une erreur en cache, et le verrou est toujours relâché (pas de « poison ») ;
+//  - en cas d'échec de régénération, on ressert le dernier bon XML s'il existe (stale-on-error),
+//    sinon on propage l'erreur, ce qui est exactement le comportement de l'ancien code.
+export function créerCacheSitemap(générer: () => Promise<string>, options: OptionsCacheSitemap): () => Promise<string> {
+	let xmlEnCache: string | null = null;
+	let expiration = 0;
+	let générationEnCours: Promise<string> | null = null;
+
+	const compterUrls = (xml: string): number => (xml.match(/<url>/g) ?? []).length;
+
+	return async function obtenirSitemap(): Promise<string> {
+		if (xmlEnCache !== null && Date.now() < expiration) {
+			return xmlEnCache;
+		}
+		// Une seule régénération à la fois : les appels concurrents partagent cette promesse.
+		if (générationEnCours === null) {
+			générationEnCours = (async () => {
+				try {
+					const xml = await générer();
+					if (compterUrls(xml) >= options.seuilMinUrls) {
+						xmlEnCache = xml;
+						expiration = Date.now() + options.ttlMs;
+					}
+					return xml;
+				} finally {
+					générationEnCours = null;
+				}
+			})();
+		}
+		try {
+			return await générationEnCours;
+		} catch (erreur) {
+			if (xmlEnCache !== null) {
+				return xmlEnCache;
+			}
+			throw erreur;
+		}
+	};
+}


### PR DESCRIPTION
## Contexte

Le conteneur web unique du CMS `1j1s-main-cms-prod` a crashé plusieurs fois en production (24/06 et 05/07 2026 : « container stopped working + restart auto »). Cause identifiée : la route `/sitemap.xml` (rewrite vers `/api/sitemap`) régénère l'intégralité du sitemap à **chaque** requête, sans cache. Pour la collection annonces-de-logement (~850 pages), le client Strapi récupérait toutes les pages via un `Promise.all` non borné, envoyant des centaines de requêtes quasi simultanées au CMS (pics mesurés ~430 req/s, ~2000 réponses `503 container=false`) jusqu'à la saturation puis le crash.

## Changements

### Cache du sitemap (correctif racine)
* Cache en mémoire du XML avec verrou **single-flight** : les requêtes concurrentes partagent une seule régénération au lieu d'en déclencher chacune une (c'est ce qui supprime la rafale, y compris au démarrage à froid après un redémarrage).
* TTL 6h par défaut, pilotable via `SITEMAP_CACHE_TTL_S`.
* Garde-fous : on ne met en cache que les réponses valides (seuil plancher d'URLs), jamais une erreur ; en cas d'échec de régénération on ressert le dernier bon XML (stale-on-error), sinon `503` + `Retry-After` (jamais un sitemap vide, qui ferait déréférencer les URLs chez Google).
* Headers `Cache-Control` (s-maxage 6h) et `X-Content-Type-Options: nosniff`.

### Plafond de concurrence (filet)
* `getCollectionType` récupère les pages restantes par **lots bornés** (5 requêtes simultanées) au lieu d'un `Promise.all` sur toutes les pages. Comportement identique (mêmes pages, même ordre), charge lissée. Corrige au passage un risque de `RangeError` sur le spread de dizaines de milliers d'éléments.

### Validation d'identifiant (engagement)
* Bloque en amont les requêtes de mission dont l'identifiant n'est pas un ObjectId valide, pour ne pas solliciter l'API externe inutilement.

## Tests
* `sitemapCache.test.ts` : hit frais (une seule génération), single-flight concurrent, pas de cache sur erreur ni sous le seuil, stale-on-error.
* `strapi.service.test.ts` : non-régression du plafond de concurrence.
* Suite existante verte.

## Validation en recette (avant prod)
1. `curl -sI https://<recette>/sitemap.xml` deux fois : le 2e appel doit être quasi instantané.
2. 50 requêtes concurrentes sur `/sitemap.xml` : une seule vague de régénération dans les logs du CMS recette `1j1s-main-cms`, plus de rafale, zéro `503 container=false`.

## Déploiement
À déployer **avant** la PR CMS (durcissement du pool) : ce correctif traite la cause, le pool est un renfort. Rollback = revert du commit du cache.
