### PR TITLE
fix(recherche): passe le combobox localisation au facet search Meilisearch

### DIFF
--- a/src/client/components/features/Evenement/FormulaireRecherche/FormulaireRechercheEvenement.tsx
+++ b/src/client/components/features/Evenement/FormulaireRecherche/FormulaireRechercheEvenement.tsx
@@ -5,8 +5,6 @@ import styles
 import { MeilisearchComboboxLocalisation } from '~/client/components/ui/Meilisearch/MeilisearchComboboxLocalisation/MeilisearchComboboxLocalisation';
 import { MeilisearchInput } from '~/client/components/ui/Meilisearch/MeilisearchInput/MeilisearchInput';
 
-const LIMIT_MAX_FACETS = 10000;
-
 export function FormulaireRechercheEvenement() {
 	return (
 		<form className={styles.rechercherEvenementForm} onSubmit={(event) => event.preventDefault()}>
@@ -15,8 +13,7 @@ export function FormulaireRechercheEvenement() {
 				name="motCle"
 				placeholder="Exemples : gendarmerie, cuisinier, mentorat" />
 	  <MeilisearchComboboxLocalisation
-				attribute="lieuEvenement"
-				limit={LIMIT_MAX_FACETS} />
+				attribute="lieuEvenement" />
 		</form>
 	);
 }

--- a/src/client/components/features/OffreDeStage/FormulaireRecherche/FormulaireRechercheOffreStage.tsx
+++ b/src/client/components/features/OffreDeStage/FormulaireRecherche/FormulaireRechercheOffreStage.tsx
@@ -8,7 +8,6 @@ import { MeilisearchInput } from '~/client/components/ui/Meilisearch/Meilisearch
 import { MeilisearchSelectMultiple } from '~/client/components/ui/Meilisearch/MeilisearchSelectMultiple/MeilisearchSelectMultiple';
 import { DomainesStage } from '~/server/stages/repository/domainesStage';
 
-const LIMIT_MAX_FACETS = 100000;
 const LIMIT_MAX_DOMAINS = 100;
 
 function sortASCII(a: SearchResults.FacetValue, b: SearchResults.FacetValue) {
@@ -49,8 +48,7 @@ export function FormulaireRechercheOffreStage() {
 				name="motCle"
 				placeholder="Exemples : designer, juriste…" />
 			<MeilisearchComboboxLocalisation
-				attribute="localisationFiltree"
-				limit={LIMIT_MAX_FACETS} />
+				attribute="localisationFiltree" />
 			<MeilisearchSelectMultiple
 				attribute="domaines"
 				limit={LIMIT_MAX_DOMAINS}

--- a/src/client/components/ui/Meilisearch/MeilisearchComboboxLocalisation/MeilisearchComboboxLocalisation.test.tsx
+++ b/src/client/components/ui/Meilisearch/MeilisearchComboboxLocalisation/MeilisearchComboboxLocalisation.test.tsx
@@ -15,14 +15,14 @@ vi.mock('react-instantsearch');
 const spyed = vi.mocked(useRefinementList);
 
 describe('MeilisearchComboboxLocalisation', () => {
-	it('l‘utilisateur peut intéragir avec le combobox et voir les options', async () => {
+	it('délègue le filtrage à Meilisearch via searchForItems et affiche les options renvoyées', async () => {
+		const searchForItems = vi.fn();
 		spyed.mockImplementation(() => mockUseRefinementList({
 			items: [
 				generateRefinementListItem({ value: 'Paris' }),
-				generateRefinementListItem({ value: 'Marseille' }),
-				generateRefinementListItem({ value: 'PACA' }),
-				generateRefinementListItem({ value: 'Le Vésinet' })],
+				generateRefinementListItem({ value: 'PACA' })],
 			refine: vi.fn(),
+			searchForItems,
 		}));
 		const user = userEvent.setup();
 
@@ -31,6 +31,7 @@ describe('MeilisearchComboboxLocalisation', () => {
 		await user.type(combobox, 'p');
 
 		expect(combobox).toHaveValue('p');
+		expect(searchForItems).toHaveBeenCalledWith('p');
 		const options = screen.getAllByRole('option');
 		expect(options.length).toBe(2);
 		expect(options[0]).toHaveTextContent('Paris');

--- a/src/client/components/ui/Meilisearch/MeilisearchComboboxLocalisation/MeilisearchComboboxLocalisation.tsx
+++ b/src/client/components/ui/Meilisearch/MeilisearchComboboxLocalisation/MeilisearchComboboxLocalisation.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { useRefinementList, UseRefinementListProps } from 'react-instantsearch';
 
 import { KeyBoard } from '~/client/components/keyboard/keyboard.enum';
@@ -11,24 +11,23 @@ const NOMBRE_RESULTAT_MAXIMUM = 20;
 const INPUT_VALUE_NAME = 'inputLocalisation';
 
 export function MeilisearchComboboxLocalisation(props: UseRefinementListProps) {
-	const { refine, items } = useRefinementList(props);
+	const { refine, items, searchForItems } = useRefinementList({ ...props, limit: NOMBRE_RESULTAT_MAXIMUM });
 	const [userInput, setUserInput] = useState<string>('');
 	const comboboxRef = useRef<HTMLInputElement>(null);
 
-	const filterLocalisations = useCallback(function filterLocalisation() {
-		function isLocalisationMatchingUserInput(localisation: string) {
-			return localisation.toLowerCase().includes(userInput.toLowerCase());
-		}
+	const listeDeLocalisations = useMemo(
+		() => items.filter(({ isRefined }) => !isRefined).map(({ value }) => value).slice(0, NOMBRE_RESULTAT_MAXIMUM),
+		[items]);
 
-		return items.filter(({ value, isRefined }) => !isRefined && isLocalisationMatchingUserInput(value));
-	}, [items, userInput]);
-
-	const listeDeLocalisations = useMemo(() => filterLocalisations().map(({ value }) => value).slice(0, NOMBRE_RESULTAT_MAXIMUM),
-		[filterLocalisations]);
+	function rechercherLocalisations(saisie: string) {
+		setUserInput(saisie);
+		searchForItems(saisie);
+	}
 
 	function onOptionSelected(localisation: string) {
 		refine(localisation);
 		setUserInput('');
+		searchForItems('');
 	}
 
 	function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
@@ -66,7 +65,7 @@ export function MeilisearchComboboxLocalisation(props: UseRefinementListProps) {
 				autoComplete="off"
 				filter={Combobox.noFilter}
 				onChange={(_, newValue) => {
-					setUserInput(newValue);
+					rechercherLocalisations(newValue);
 				}}>
 				{listeDeLocalisations.map((suggestion) => (
 					<Combobox.Option key={suggestion} onClick={onClickOnOption}>


### PR DESCRIPTION
## Quoi
Le combobox de localisation (`MeilisearchComboboxLocalisation`) passe au facet search Meilisearch (`searchForItems`) au lieu de charger toute la distribution des facettes puis de filtrer côté client. Les formulaires stages et évènement sont nettoyés du `limit={LIMIT_MAX_FACETS}` (100000) devenu inutile.

## Pourquoi
Le facet search n'est pas borné par `maxValuesPerFacet`. Cela permet d'abaisser ce plafond côté CMS (PR associée) sans tronquer la liste des villes, et réduit le coût des facettes (fin de la distribution complète chargée à chaque recherche).

## Ordre de déploiement
Cette PR front AVANT la PR CMS qui abaisse `maxValuesPerFacet` à 200. Le facet search fonctionne quel que soit le plafond, donc la déployer d'abord ne change rien pour l'utilisateur et rend ensuite l'abaissement du plafond sans risque.

## Vérifs
* Tests unitaires du composant : 7 sur 7
* Zone stages, évènement, composants Meilisearch : 140 sur 140
* `tsc --noEmit` et `eslint` : verts
* Preuve moteur (Meilisearch local, plus de 300 villes, `maxValuesPerFacet=200`) : la distribution tronque à 200, le facet search remonte tout de même « Ville-300 », située au delà du plafond
* Logement non concerné (la ville y est une recherche plein texte, pas une facette)

## Reste à faire côté recette
Vérif visuelle : taper une ville dans le filtre localisation de `/stages` et confirmer qu'elle remonte (preuve moteur déjà faite en local).
